### PR TITLE
docs: add Simulacrum logo and badge header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+![Simulacrum Logo](https://github.com/Smlcrm/smlcrm-brand-assets/blob/main/Asset%201@4x-8.png?raw=true "Simulacrum — TempusBench")
+
 # Time Series Forecasting Benchmarking Pipeline (`tempus_bench`)
+
+[![License: CC BY-NC-ND 4.0](https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/)
+[![Version](https://img.shields.io/badge/version-1.0.0-brightgreen.svg)](https://github.com/Smlcrm/TempusBench/releases)
 
 A comprehensive framework for benchmarking time series forecasting models, including both traditional statistical models and modern foundation models.
 


### PR DESCRIPTION
## Summary
- Reformat the README header to match the Chronax style: the Simulacrum logo at the top, followed by license, Python version, and version badges.
- Badges: License `CC-BY-NC-ND-4.0` (matches `pyproject.toml`), Python `3.11` (documented env), Version `1.0.0` (from `pyproject.toml`).
- Mirrors the same change merged into `prod`.

## Test plan
- [ ] Confirm the logo and three badges render at the top of the README.

Made with [Cursor](https://cursor.com)