### PR TITLE
feat(metrics): add unbiased multivariate energy score

### DIFF
--- a/tempus_bench/metrics/__init__.py
+++ b/tempus_bench/metrics/__init__.py
@@ -6,6 +6,7 @@ time series forecasting models, including both point forecasts and probabilistic
 
 Available Metrics:
 - crps: Continuous Ranked Probability Score for stochastic forecasts
+- energy_score: Multivariate Energy Score from samples (stochastic; beta=1)
 - weighted_interval_score: Weighted Interval Score for prediction intervals (stochastic)
 - quantile_score: Quantile Score for stochastic forecasts
 - mae: Mean Absolute Error (deterministic and stochastic)
@@ -15,7 +16,7 @@ Available Metrics:
 
 Task Type Requirements:
 - deterministic: mae, rmse, mape, mase
-- stochastic: crps, quantile_score, weighted_interval_score, mae, rmse
+- stochastic: crps, energy_score, quantile_score, weighted_interval_score, mae, rmse
 
 All metrics accept an optional 'model_type' parameter in kwargs to validate compatibility.
 If not provided, metrics default to their compatible task type.

--- a/tempus_bench/metrics/energy_score.py
+++ b/tempus_bench/metrics/energy_score.py
@@ -1,0 +1,54 @@
+"""
+Calculates the multivariate Energy Score from forecast samples.
+
+Uses the unbiased S-sample estimator with beta fixed at 1:
+
+    ES = (1/S) sum_i ||s_i - y||_2
+         - (1 / (2 S (S-1))) sum_{i != j} ||s_i - s_j||_2
+
+Each sample and the observation are treated as vectors in R^{T*M}
+(time and targets flattened). When S == 1 the pairwise term is 0.
+"""
+
+import numpy as np
+
+from .base_metric import BaseMetric
+
+
+class EnergyScore(BaseMetric):
+    def __init__(self):
+        super().__init__("stochastic")
+
+    def _compute(self, y_true: np.ndarray, y_pred: np.ndarray, **kwargs) -> float:
+        """
+        Computes the unbiased multivariate Energy Score with beta=1.
+
+        Args:
+            y_true: True values, shape (n_timesteps, num_targets).
+            y_pred: Forecast samples (preprocessed by base class),
+                shape (num_samples, n_timesteps, num_targets).
+            **kwargs: Unused; beta is hardcoded to 1.
+
+        Returns:
+            Scalar energy score over the full (T, M) forecast vector.
+        """
+        if y_true.ndim == 1:
+            raise ValueError("y_true must be 2D array, got 1D array")
+        if y_pred.ndim != 3:
+            raise ValueError(
+                f"Expected 3D y_pred for energy score, got shape {y_pred.shape}"
+            )
+
+        S = y_pred.shape[0]
+        flat_s = y_pred.reshape(S, -1)
+        flat_y = y_true.reshape(-1)
+
+        term1 = np.mean(np.linalg.norm(flat_s - flat_y, axis=1))
+        if S < 2:
+            return float(term1)
+
+        diffs = flat_s[:, None, :] - flat_s[None, :, :]
+        pair = np.linalg.norm(diffs, axis=-1)
+        off = ~np.eye(S, dtype=bool)
+        term2 = pair[off].sum() / (2.0 * S * (S - 1))
+        return float(term1 - term2)

--- a/tests/unit/test_metrics_stochastic.py
+++ b/tests/unit/test_metrics_stochastic.py
@@ -1,5 +1,5 @@
 """
-Unit tests for stochastic metrics: CRPS, QuantileScore, WeightedIntervalScore.
+Unit tests for stochastic metrics: CRPS, EnergyScore, QuantileScore, WeightedIntervalScore.
 
 Tests cover:
 - Basic stochastic calculations with sample distributions
@@ -14,6 +14,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_raises
 
 from tempus_bench.metrics.crps import CRPS
+from tempus_bench.metrics.energy_score import EnergyScore
 from tempus_bench.metrics.quantile_score import QuantileScore
 from tempus_bench.metrics.weighted_interval_score import WeightedIntervalScore
 
@@ -106,6 +107,64 @@ class TestCRPS:
         
         result = crps(y_true, y_pred, model_type='stochastic')
         assert result >= 0
+
+
+class TestEnergyScore:
+    """Test EnergyScore metric (stochastic; unbiased multivariate ES, beta=1)."""
+
+    def test_perfect_predictions(self):
+        """All samples equal to y => energy score is 0."""
+        es = EnergyScore()
+        y_true = np.array([[1.0, 2.0], [3.0, 4.0]])
+        y_pred = np.broadcast_to(y_true, (5, 2, 2)).copy()
+        result = es(y_true, y_pred, model_type="stochastic")
+        assert_allclose(result, 0.0, atol=1e-12)
+
+    def test_hand_checked_s2_univariate(self):
+        """S=2 univariate case against the closed-form unbiased estimator."""
+        # y=0, samples={1, 3}
+        # term1 = (|1-0| + |3-0|) / 2 = 2
+        # term2 = (|1-3| + |3-1|) / (2*2*1) = 1
+        # ES = 2 - 1 = 1
+        es = EnergyScore()
+        y_true = np.array([[0.0]])
+        y_pred = np.array([[[1.0]], [[3.0]]])  # (S=2, T=1, M=1)
+        result = es(y_true, y_pred, model_type="stochastic")
+        assert_allclose(result, 1.0, atol=1e-12)
+
+    def test_single_sample(self):
+        """S=1 => pairwise term is 0; score equals ||s - y||_2."""
+        es = EnergyScore()
+        y_true = np.array([[2.0]])
+        y_pred = np.array([[[2.5]]])  # (1, 1, 1)
+        result = es(y_true, y_pred, model_type="stochastic")
+        assert_allclose(result, 0.5, atol=1e-12)
+
+    def test_multivariate_joint_norm(self):
+        """Score uses one L2 over the full (T, M) vector, not elementwise mean."""
+        # y = (0, 0), one sample s = (3, 4) => ||s-y||_2 = 5
+        es = EnergyScore()
+        y_true = np.array([[0.0, 0.0]])
+        y_pred = np.array([[[3.0, 4.0]]])  # (1, 1, 2)
+        result = es(y_true, y_pred, model_type="stochastic")
+        assert_allclose(result, 5.0, atol=1e-12)
+
+    def test_shape_validation_incorrect(self):
+        """Mismatched y_true / y_pred shapes raise via BaseMetric."""
+        es = EnergyScore()
+        y_true = np.array([2.0, 3.0])  # Wrong shape
+        y_pred = np.random.randn(50, 2, 2)
+        with pytest.raises(ValueError, match="Shape mismatch"):
+            es(y_true, y_pred, model_type="stochastic")
+
+    def test_hybrid_uses_samples(self):
+        """Hybrid model_type feeds sample tensor into the stochastic metric."""
+        es = EnergyScore()
+        y_true = np.array([[0.0]])
+        point = np.array([[99.0]])
+        samples = np.array([[[1.0]], [[3.0]]])  # same as hand-checked case
+        result = es(y_true, (point, samples), model_type="hybrid")
+        assert_allclose(result, 1.0, atol=1e-12)
 
 
 class TestQuantileScore:


### PR DESCRIPTION
## Summary
- Add stochastic `EnergyScore` metric (beta hardcoded to 1) using LAFN’s unbiased sample estimator over the full (T, M) forecast vector
- Register via auto-discovery; document in metrics package docstring
- Unit tests for perfect predictions, hand-checked S=2 case, S=1 edge case, shape validation, and hybrid path

## Test plan
- [x] `pytest tests/unit/test_metrics_stochastic.py::TestEnergyScore -v`
- [x] Confirm `MetricRegistry` lists `energy_score` as stochastic
- [ ] Spot-check a stochastic/hybrid model eval includes `energy_score` in metrics output


Made with [Cursor](https://cursor.com)