### PR TITLE
Add web docs generation (replicates Chronax setup)

### DIFF
--- a/web-docs/Dockerfile
+++ b/web-docs/Dockerfile
@@ -1,0 +1,14 @@
+# Serve-only image for Cloud Run. The docs are generated in a Cloud Build step
+# (see cloudbuild.yaml) which writes ./site and ./serve.py into the build
+# context, so this image just serves the prebuilt static site.
+#
+# Generation is kept out of the image on purpose: the Gemini key stays in the
+# build step (never an image layer), and the persistent GCS doc cache lives in
+# the build step too, so only changed modules are regenerated.
+FROM python:3.12-slim
+WORKDIR /app
+COPY site /app/site
+COPY serve.py /app/serve.py
+ENV PORT=8080
+EXPOSE 8080
+CMD ["python", "/app/serve.py"]

--- a/web-docs/cloudbuild.yaml
+++ b/web-docs/cloudbuild.yaml
@@ -1,0 +1,71 @@
+# Generate the TempusBench docs (only regenerating changed modules via a
+# persistent GCS cache) and deploy to Cloud Run.
+#
+# Set these in the trigger's substitution variables:
+#   _GEMINI_API_KEY  your Gemini key
+#   _DOCGEN_TOKEN    GitHub PAT for the private web-doc-generator (drop when public)
+#
+# The doc cache is keyed by a hash of each module's source + prompt, so a build
+# only calls Gemini for modules whose source (or a prompt) changed since last time.
+
+substitutions:
+  _GEMINI_API_KEY: ""
+  _DOCGEN_TOKEN: ""
+  _CACHE_BUCKET: gs://sml-web-doc-gen-dev-docgen-cache/tempusbench
+  _DOCGEN_REF: prod
+  _SERVICE_NAME: web-docs-tempusbench-dev
+  _DEPLOY_REGION: us-central1
+  _IMAGE: us-central1-docker.pkg.dev/sml-web-doc-gen-dev/cloud-run-source-deploy/tempusbench/web-docs-tempusbench-dev
+
+steps:
+  # 1. Generate docs with a persistent cache: restore from GCS, run docgen (only
+  #    cache-miss modules call Gemini), then save the cache back.
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        apt-get update -qq && apt-get install -y -qq git python3-venv >/dev/null
+        git clone --depth 1 --branch "${_DOCGEN_REF}" \
+          "https://x-access-token:${_DOCGEN_TOKEN}@github.com/Smlcrm/web-doc-generator.git" /docgen
+        python3 -m venv /venv
+        /venv/bin/pip install -q -r /docgen/requirements.txt
+
+        mkdir -p /docgen/.docgen-cache
+        echo "Restoring doc cache from ${_CACHE_BUCKET} ..."
+        gsutil -m rsync -r "${_CACHE_BUCKET}" /docgen/.docgen-cache || true
+
+        echo "Generating docs (cache hits skip Gemini) ..."
+        GEMINI_API_KEY="${_GEMINI_API_KEY}" PYTHONPATH=/docgen \
+          /venv/bin/python -m docgen --repo /workspace --out /workspace/site \
+          --config /workspace/web-docs/docgen.toml
+        cp /docgen/serve.py /workspace/serve.py
+
+        echo "Saving doc cache to ${_CACHE_BUCKET} ..."
+        gsutil -m rsync -d -r /docgen/.docgen-cache "${_CACHE_BUCKET}"
+
+  # 2. Build the serve-only image (copies the prebuilt ./site + ./serve.py).
+  - name: gcr.io/cloud-builders/docker
+    args: [build, -t, "${_IMAGE}:${COMMIT_SHA}", ., -f, web-docs/Dockerfile]
+
+  # 3. Push, then 4. deploy.
+  - name: gcr.io/cloud-builders/docker
+    args: [push, "${_IMAGE}:${COMMIT_SHA}"]
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - services
+      - update
+      - ${_SERVICE_NAME}
+      - --platform=managed
+      - --image=${_IMAGE}:${COMMIT_SHA}
+      - --region=${_DEPLOY_REGION}
+      - --quiet
+
+images:
+  - ${_IMAGE}:${COMMIT_SHA}
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/web-docs/cloudbuild.yaml
+++ b/web-docs/cloudbuild.yaml
@@ -62,6 +62,9 @@ steps:
       - --platform=managed
       - --image=${_IMAGE}:${COMMIT_SHA}
       - --region=${_DEPLOY_REGION}
+      # The serve container reads GEMINI_API_KEY at runtime to power the
+      # "Ask AI" chat endpoint; without it the site is served fully static.
+      - --update-env-vars=GEMINI_API_KEY=${_GEMINI_API_KEY}
       - --quiet
 
 images:

--- a/web-docs/docgen.toml
+++ b/web-docs/docgen.toml
@@ -1,0 +1,10 @@
+# Documentation config for docgen (github.com/Smlcrm/web-doc-generator).
+# Passed explicitly via --config in web-docs/cloudbuild.yaml.
+
+[project]
+name = "TempusBench"
+description = "A unified benchmarking framework for time series forecasting, comparing traditional and foundation models with automated pipelines and isolated execution."
+package = "tempus_bench"
+
+[theme]
+preset = "simulacrum"


### PR DESCRIPTION
## What

Adds the `web-docs/` subfolder that powers the auto-generated documentation site, replicating the Chronax setup (Chronax PRs #96/#97):

- `docgen.toml` — project name/description/package (`tempus_bench`) + Simulacrum theme
- `cloudbuild.yaml` — generates docs via [web-doc-generator](https://github.com/Smlcrm/web-doc-generator) with a persistent GCS cache (`.../tempusbench`), builds the serve image, deploys to the `web-docs-tempusbench-dev` Cloud Run service
- `Dockerfile` — serve-only image (docs are generated in the build step, so no keys land in image layers)

Includes the Ask AI chat: the deploy passes `GEMINI_API_KEY` to the service, enabling the `/api/chat` endpoint (grounded in the docs search index, per-IP rate-limited).

## Infra

Cloud Run service `web-docs-tempusbench-dev` exists (us-central1, public). The push trigger can't be created yet — the Cloud Build GitHub App needs access to this repo, which requires an org admin. Until then, builds are submitted manually.