### PR TITLE
Add comment for repository link in instructions

### DIFF
--- a/web-docs/docgen.toml
+++ b/web-docs/docgen.toml
@@ -5,6 +5,7 @@
 name = "TempusBench"
 description = "A unified benchmarking framework for time series forecasting, comparing traditional and foundation models with automated pipelines and isolated execution."
 package = "tempus_bench"
+# instructions = [add repo link to the instructions]
 
 [theme]
 preset = "simulacrum"


### PR DESCRIPTION
Added a comment to indicate where to add the repository link in the instructions section.