### PR TITLE
ci: add GitHub Actions web docs pipeline

### DIFF
--- a/.github/workflows/web-docs-dev.yml
+++ b/.github/workflows/web-docs-dev.yml
@@ -33,7 +33,10 @@ env:
   # on 2026-08-02). The first run after that is a cold build: every module
   # goes through Gemini. Subsequent runs only regenerate what changed.
   CACHE_BUCKET: gs://sml-website-dev-docgen-cache/tempusbench
-  SECRET_PROJECT_ID: sml-website-dev
+  # Generation runs against Vertex AI through ADC. There is no API key: org
+  # policy forbids long-lived keys, and the job is already federated via WIF.
+  VERTEX_PROJECT_ID: sml-website-dev
+  VERTEX_LOCATION: us-central1
   BUILDER_IMAGE: us-central1-docker.pkg.dev/sml-artifacts-dev/sml-web-doc-docker/docgen-builder:latest
 
 jobs:
@@ -56,16 +59,6 @@ jobs:
       - name: Configure Docker auth
         run: gcloud auth configure-docker "${ARTIFACT_REGION}-docker.pkg.dev" --quiet
 
-      - name: Read the Gemini key from Secret Manager
-        id: secret
-        run: |
-          set -euo pipefail
-          KEY="$(gcloud secrets versions access latest \
-            --secret=web-doc-gemini-api-key \
-            --project="${SECRET_PROJECT_ID}")"
-          echo "::add-mask::${KEY}"
-          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
-
       - name: Restore the doc cache
         run: |
           mkdir -p .docgen-cache
@@ -74,14 +67,21 @@ jobs:
       - name: Generate the docs
         run: |
           set -euo pipefail
+          # RUNNER_TEMP is mounted at the same path inside the container so the
+          # ADC file written by google-github-actions/auth resolves, including
+          # the OIDC token file it points at. No credential is ever copied.
           docker run --rm \
-            -e GEMINI_API_KEY \
+            -e GOOGLE_APPLICATION_CREDENTIALS \
+            -e GOOGLE_CLOUD_PROJECT \
+            -e GOOGLE_CLOUD_LOCATION \
+            -v "${RUNNER_TEMP}:${RUNNER_TEMP}:ro" \
             -v "${PWD}:/work" \
             -v "${PWD}/.docgen-cache:/app/.docgen-cache" \
             "${BUILDER_IMAGE}" \
             --repo /work --out /work/site --config /work/web-docs/docgen.toml
         env:
-          GEMINI_API_KEY: ${{ steps.secret.outputs.key }}
+          GOOGLE_CLOUD_PROJECT: ${{ env.VERTEX_PROJECT_ID }}
+          GOOGLE_CLOUD_LOCATION: ${{ env.VERTEX_LOCATION }}
 
       - name: Verify the site actually generated
         run: |
@@ -120,34 +120,17 @@ jobs:
           REF="${IMAGE}@${{ steps.push.outputs.digest }}"
           LABELS="managed-by=github-actions,source-repo=tempusbench,commit-sha=${GITHUB_SHA},environment=dev"
 
-          # The dev services were destroyed with sml-web-doc-gen-dev on
-          # 2026-08-02, so the first run in sml-website-dev must CREATE them.
-          # `services update` fails on a missing service; `deploy` creates or
-          # updates. Prefer update once the service exists so we never restate
-          # config that belongs elsewhere.
-          if gcloud run services describe "${SERVICE_NAME}" \
-               --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
-               --format='value(metadata.name)' >/dev/null 2>&1; then
-            echo "Service exists, rolling the image forward."
-            gcloud run services update "${SERVICE_NAME}" \
-              --image="${REF}" \
-              --project="${RUNTIME_PROJECT_ID}" \
-              --region="${CLOUD_RUN_REGION}" \
-              --update-labels="${LABELS}" \
-              --quiet
-          else
-            echo "Service absent, creating it (first deploy after the project move)."
-            gcloud run deploy "${SERVICE_NAME}" \
-              --image="${REF}" \
-              --project="${RUNTIME_PROJECT_ID}" \
-              --region="${CLOUD_RUN_REGION}" \
-              --platform=managed \
-              --allow-unauthenticated \
-              --port=8080 \
-              --set-secrets=GEMINI_API_KEY=web-doc-gemini-api-key:latest \
-              --labels="${LABELS}" \
-              --quiet
-          fi
+          # Update only. The service definition (ingress, invoker, runtime SA,
+          # scaling, env) is owned by Terraform; anything set here would be
+          # invisible to it and read as unmanaged drift. This step rolls the
+          # image forward and nothing else, so it fails loudly if the service
+          # has not been provisioned yet.
+          gcloud run services update "${SERVICE_NAME}" \
+            --image="${REF}" \
+            --project="${RUNTIME_PROJECT_ID}" \
+            --region="${CLOUD_RUN_REGION}" \
+            --update-labels="${LABELS}" \
+            --quiet
 
       - name: Verify the deployed revision serves
         run: |

--- a/.github/workflows/web-docs-dev.yml
+++ b/.github/workflows/web-docs-dev.yml
@@ -1,0 +1,163 @@
+# Generate the TempusBench docs and deploy them to the dev Cloud Run service.
+#
+# Replaces the Cloud Build trigger. The Gemini key comes from Secret Manager
+# at generate time, never from a substitution or an image layer.
+name: Web docs (tempusbench dev)
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'tempus_bench/**'
+      - 'web-docs/**'
+      - '.github/workflows/web-docs-dev.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: web-docs-tempusbench-dev
+  cancel-in-progress: true
+
+env:
+  PROJECT_SLUG: tempusbench
+  ARTIFACT_PROJECT_ID: sml-artifacts-dev
+  ARTIFACT_REGION: us-central1
+  ARTIFACT_REPOSITORY: sml-web-doc-docker
+  RUNTIME_PROJECT_ID: sml-website-dev
+  SERVICE_NAME: web-docs-tempusbench-dev
+  CLOUD_RUN_REGION: us-central1
+  # Recreated in sml-website-dev (the original died with sml-web-doc-gen-dev
+  # on 2026-08-02). The first run after that is a cold build: every module
+  # goes through Gemini. Subsequent runs only regenerate what changed.
+  CACHE_BUCKET: gs://sml-website-dev-docgen-cache/tempusbench
+  SECRET_PROJECT_ID: sml-website-dev
+  BUILDER_IMAGE: us-central1-docker.pkg.dev/sml-artifacts-dev/sml-web-doc-docker/docgen-builder:latest
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: sml-bootstrap-cicd
+          workload_identity_provider: projects/972498125049/locations/global/workloadIdentityPools/github-pool-sml-bootstrap-cicd/providers/github
+          service_account: github-ci-sml-bootstrap-cicd@sml-bootstrap-cicd.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker "${ARTIFACT_REGION}-docker.pkg.dev" --quiet
+
+      - name: Read the Gemini key from Secret Manager
+        id: secret
+        run: |
+          set -euo pipefail
+          KEY="$(gcloud secrets versions access latest \
+            --secret=web-doc-gemini-api-key \
+            --project="${SECRET_PROJECT_ID}")"
+          echo "::add-mask::${KEY}"
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the doc cache
+        run: |
+          mkdir -p .docgen-cache
+          gsutil -m rsync -r "${CACHE_BUCKET}" .docgen-cache || true
+
+      - name: Generate the docs
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e GEMINI_API_KEY \
+            -v "${PWD}:/work" \
+            -v "${PWD}/.docgen-cache:/app/.docgen-cache" \
+            "${BUILDER_IMAGE}" \
+            --repo /work --out /work/site --config /work/web-docs/docgen.toml
+        env:
+          GEMINI_API_KEY: ${{ steps.secret.outputs.key }}
+
+      - name: Verify the site actually generated
+        run: |
+          set -euo pipefail
+          test -f site/index.html || { echo "::error::site/index.html missing"; exit 1; }
+          COUNT="$(find site -name '*.html' | wc -l)"
+          echo "generated ${COUNT} html file(s)"
+          [ "${COUNT}" -gt 1 ] || { echo "::error::only ${COUNT} page(s) generated"; exit 1; }
+
+      - name: Save the doc cache
+        run: gsutil -m rsync -d -r .docgen-cache "${CACHE_BUCKET}"
+
+      - name: Stage serve.py from the builder image
+        run: |
+          set -euo pipefail
+          CID="$(docker create "${BUILDER_IMAGE}")"
+          docker cp "${CID}:/app/serve.py" ./serve.py
+          docker rm "${CID}"
+          test -f serve.py
+
+      - name: Build and push the serve-only image
+        id: push
+        run: |
+          set -euo pipefail
+          IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          docker build -t "${IMAGE}:sha-${GITHUB_SHA}" -f web-docs/Dockerfile .
+          docker push "${IMAGE}:sha-${GITHUB_SHA}"
+          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE}:sha-${GITHUB_SHA}" | cut -d@ -f2)"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Pushed ${IMAGE}@${DIGEST}"
+
+      - name: Deploy dev by digest
+        run: |
+          set -euo pipefail
+          IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          REF="${IMAGE}@${{ steps.push.outputs.digest }}"
+          LABELS="managed-by=github-actions,source-repo=tempusbench,commit-sha=${GITHUB_SHA},environment=dev"
+
+          # The dev services were destroyed with sml-web-doc-gen-dev on
+          # 2026-08-02, so the first run in sml-website-dev must CREATE them.
+          # `services update` fails on a missing service; `deploy` creates or
+          # updates. Prefer update once the service exists so we never restate
+          # config that belongs elsewhere.
+          if gcloud run services describe "${SERVICE_NAME}" \
+               --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+               --format='value(metadata.name)' >/dev/null 2>&1; then
+            echo "Service exists, rolling the image forward."
+            gcloud run services update "${SERVICE_NAME}" \
+              --image="${REF}" \
+              --project="${RUNTIME_PROJECT_ID}" \
+              --region="${CLOUD_RUN_REGION}" \
+              --update-labels="${LABELS}" \
+              --quiet
+          else
+            echo "Service absent, creating it (first deploy after the project move)."
+            gcloud run deploy "${SERVICE_NAME}" \
+              --image="${REF}" \
+              --project="${RUNTIME_PROJECT_ID}" \
+              --region="${CLOUD_RUN_REGION}" \
+              --platform=managed \
+              --allow-unauthenticated \
+              --port=8080 \
+              --set-secrets=GEMINI_API_KEY=web-doc-gemini-api-key:latest \
+              --labels="${LABELS}" \
+              --quiet
+          fi
+
+      - name: Verify the deployed revision serves
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${SERVICE_NAME}" \
+            --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+            --format='value(status.url)')"
+          for i in $(seq 1 10); do
+            CODE="$(curl -s -o /dev/null -w '%{http_code}' "${URL}")"
+            [ "${CODE}" = "200" ] && { echo "OK ${URL}"; exit 0; }
+            echo "attempt ${i}: HTTP ${CODE}"; sleep 6
+          done
+          echo "::error::${URL} never returned 200"; exit 1

--- a/.github/workflows/web-docs-dev.yml
+++ b/.github/workflows/web-docs-dev.yml
@@ -1,7 +1,7 @@
 # Generate the TempusBench docs and deploy them to the dev Cloud Run service.
 #
-# Replaces the Cloud Build trigger. The Gemini key comes from Secret Manager
-# at generate time, never from a substitution or an image layer.
+# Replaces the Cloud Build trigger. Generation authenticates to Vertex AI
+# through ADC, so there is no API key anywhere in this pipeline.
 name: Web docs (tempusbench dev)
 
 on:
@@ -36,7 +36,9 @@ env:
   # Generation runs against Vertex AI through ADC. There is no API key: org
   # policy forbids long-lived keys, and the job is already federated via WIF.
   VERTEX_PROJECT_ID: sml-website-dev
-  VERTEX_LOCATION: us-central1
+  # Matches what Terraform sets on the runtime services, so generation and
+  # Ask AI both hit the same endpoint.
+  VERTEX_LOCATION: global
   BUILDER_IMAGE: us-central1-docker.pkg.dev/sml-artifacts-dev/sml-web-doc-docker/docgen-builder:latest
 
 jobs:
@@ -132,15 +134,35 @@ jobs:
             --update-labels="${LABELS}" \
             --quiet
 
-      - name: Verify the deployed revision serves
+      - name: Verify the new revision converged
         run: |
           set -euo pipefail
-          URL="$(gcloud run services describe "${SERVICE_NAME}" \
-            --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
-            --format='value(status.url)')"
-          for i in $(seq 1 10); do
-            CODE="$(curl -s -o /dev/null -w '%{http_code}' "${URL}")"
-            [ "${CODE}" = "200" ] && { echo "OK ${URL}"; exit 0; }
-            echo "attempt ${i}: HTTP ${CODE}"; sleep 6
+          IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          EXPECTED="${IMAGE}@${{ steps.push.outputs.digest }}"
+
+          # The service sits behind the load balancer with internal ingress, so
+          # its run.app URL does not answer from a GitHub runner even on a good
+          # deploy. Assert convergence instead: Cloud Run must reach a Ready
+          # revision that is the newest one AND serves the digest we just built.
+          for i in $(seq 1 30); do
+            READY="$(gcloud run services describe "${SERVICE_NAME}" \
+              --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+              --format='value(status.latestReadyRevisionName)')"
+            CREATED="$(gcloud run services describe "${SERVICE_NAME}" \
+              --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+              --format='value(status.latestCreatedRevisionName)')"
+            if [ -n "${READY}" ] && [ "${READY}" = "${CREATED}" ]; then
+              SERVING="$(gcloud run revisions describe "${READY}" \
+                --project="${RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+                --format='value(spec.containers[0].image)')"
+              if [ "${SERVING}" = "${EXPECTED}" ]; then
+                echo "OK ${READY} serving ${SERVING}"
+                exit 0
+              fi
+              echo "::error::${READY} serves ${SERVING}, expected ${EXPECTED}"
+              exit 1
+            fi
+            echo "attempt ${i}: created=${CREATED} ready=${READY}"
+            sleep 6
           done
-          echo "::error::${URL} never returned 200"; exit 1
+          echo "::error::no revision became ready in time"; exit 1

--- a/.github/workflows/web-docs-promote.yml
+++ b/.github/workflows/web-docs-promote.yml
@@ -1,0 +1,171 @@
+# Promote an already-tested dev docs image to production by digest.
+#
+# No rebuild: this copies the exact bytes that the dev workflow generated,
+# tested, and deployed. The release tag names the version; the digest is
+# the through-line.
+name: Web docs (promote to prod)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA whose dev image should be promoted'
+        required: true
+      version:
+        description: 'Production tag to apply (e.g. v1.4.2)'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  # The prod registry is writable only by github-ci-promote-prod. The ordinary
+  # CI service account can read dev images but cannot write to sml-artifacts-prod,
+  # so the promote job must authenticate as the promotion account.
+  PROMOTE_SERVICE_ACCOUNT: "github-ci-promote-prod@sml-bootstrap-cicd.iam.gserviceaccount.com"
+  AUTH_PROJECT_NUMBER: "972498125049"
+  AUTH_WORKLOAD_IDENTITY_POOL: "github-pool-sml-bootstrap-cicd"
+  AUTH_WORKLOAD_IDENTITY_PROVIDER: "github"
+  PROJECT_SLUG: tempusbench
+  ARTIFACT_REGION: us-central1
+  ARTIFACT_REPOSITORY: sml-web-doc-docker
+  DEV_ARTIFACT_PROJECT_ID: sml-artifacts-dev
+  PROD_ARTIFACT_PROJECT_ID: sml-artifacts-prod
+  PROD_RUNTIME_PROJECT_ID: sml-website-prod
+  PROD_SERVICE_NAME: web-docs-tempusbench-prod
+  CLOUD_RUN_REGION: us-central1
+
+jobs:
+  promote:
+    # Two supported entry points: pushing a release tag (v*), and a manual
+    # dispatch that names the commit and version explicitly.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Resolve the commit and version being promoted
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            COMMIT="${{ inputs.commit_sha }}"
+            VERSION="${{ inputs.version }}"
+          else
+            # Tag push: GITHUB_SHA is the commit the tag points at and
+            # GITHUB_REF_NAME is the tag itself (e.g. v1.4.2).
+            COMMIT="${GITHUB_SHA}"
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          if ! printf '%s' "${COMMIT}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::commit '${COMMIT}' is not a full 40-character SHA. Dev images are tagged sha-<full sha>."
+            exit 1
+          fi
+          if [ -z "${VERSION}" ]; then
+            echo "::error::No version resolved for this promotion."
+            exit 1
+          fi
+          echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Promoting commit ${COMMIT} as ${VERSION}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: sml-bootstrap-cicd
+          workload_identity_provider: projects/${{ env.AUTH_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.AUTH_WORKLOAD_IDENTITY_POOL }}/providers/${{ env.AUTH_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.PROMOTE_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - uses: imjasonh/setup-crane@v0.4
+
+      - name: Resolve the tested dev digest
+        id: digest
+        run: |
+          set -euo pipefail
+          DEV_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${DEV_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          DIGEST="$(gcloud artifacts docker images describe \
+            "${DEV_IMAGE}:sha-${{ steps.target.outputs.commit }}" \
+            --format='value(image_summary.digest)')"
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::No dev image for commit ${{ steps.target.outputs.commit }}. Promote only commits the dev workflow has built and tested."
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${DEV_IMAGE}@${DIGEST}"
+
+      - name: Copy the digest into the production registry
+        run: |
+          set -euo pipefail
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+          DEV_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${DEV_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          PROD_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${PROD_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          crane cp \
+            "${DEV_IMAGE}@${{ steps.digest.outputs.digest }}" \
+            "${PROD_IMAGE}:${{ steps.target.outputs.version }}"
+          echo "Promoted to ${PROD_IMAGE}:${{ steps.target.outputs.version }}"
+
+      - name: Verify digest parity between dev and prod
+        run: |
+          set -euo pipefail
+          PROD_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${PROD_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          PROD_DIGEST="$(crane digest "${PROD_IMAGE}:${{ steps.target.outputs.version }}")"
+          if [ "${{ steps.digest.outputs.digest }}" != "${PROD_DIGEST}" ]; then
+            echo "::error::digest parity check FAILED: ${{ steps.digest.outputs.digest }} != ${PROD_DIGEST}"
+            exit 1
+          fi
+          echo "Digest parity OK: ${PROD_DIGEST}"
+
+      - name: Deploy production by digest
+        run: |
+          set -euo pipefail
+          PROD_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${PROD_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          REF="${PROD_IMAGE}@${{ steps.digest.outputs.digest }}"
+          LABELS="managed-by=github-actions,source-repo=tempusbench,commit-sha=${{ steps.target.outputs.commit }},release=${{ steps.target.outputs.version }},environment=prod"
+
+          # sml-website-prod was provisioned fresh, so the first promote has to
+          # CREATE the service. `services update` fails on a missing service;
+          # `deploy` creates or updates. Prefer update once it exists so we
+          # never restate config that belongs elsewhere.
+          if gcloud run services describe "${PROD_SERVICE_NAME}" \
+               --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+               --format='value(metadata.name)' >/dev/null 2>&1; then
+            echo "Service exists, rolling the image forward."
+            gcloud run services update "${PROD_SERVICE_NAME}" \
+              --image="${REF}" \
+              --project="${PROD_RUNTIME_PROJECT_ID}" \
+              --region="${CLOUD_RUN_REGION}" \
+              --update-labels="${LABELS}" \
+              --quiet
+          else
+            echo "Service absent, creating it (first promote into sml-website-prod)."
+            gcloud run deploy "${PROD_SERVICE_NAME}" \
+              --image="${REF}" \
+              --project="${PROD_RUNTIME_PROJECT_ID}" \
+              --region="${CLOUD_RUN_REGION}" \
+              --platform=managed \
+              --allow-unauthenticated \
+              --port=8080 \
+              --set-secrets=GEMINI_API_KEY=web-doc-gemini-api-key:latest \
+              --labels="${LABELS}" \
+              --quiet
+          fi
+
+      - name: Verify production serves
+        run: |
+          set -euo pipefail
+          URL="$(gcloud run services describe "${PROD_SERVICE_NAME}" \
+            --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+            --format='value(status.url)')"
+          for i in $(seq 1 10); do
+            CODE="$(curl -s -o /dev/null -w '%{http_code}' "${URL}")"
+            [ "${CODE}" = "200" ] && { echo "OK ${URL}"; exit 0; }
+            echo "attempt ${i}: HTTP ${CODE}"; sleep 6
+          done
+          echo "::error::${URL} never returned 200"; exit 1

--- a/.github/workflows/web-docs-promote.yml
+++ b/.github/workflows/web-docs-promote.yml
@@ -83,7 +83,9 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      - uses: imjasonh/setup-crane@v0.4
+      # Pinned to a commit SHA: this job holds prod-write credentials, so a
+      # moved tag here would be a supply-chain foothold. v0.4.
+      - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e
 
       - name: Resolve the tested dev digest
         id: digest
@@ -129,33 +131,16 @@ jobs:
           REF="${PROD_IMAGE}@${{ steps.digest.outputs.digest }}"
           LABELS="managed-by=github-actions,source-repo=tempusbench,commit-sha=${{ steps.target.outputs.commit }},release=${{ steps.target.outputs.version }},environment=prod"
 
-          # sml-website-prod was provisioned fresh, so the first promote has to
-          # CREATE the service. `services update` fails on a missing service;
-          # `deploy` creates or updates. Prefer update once it exists so we
-          # never restate config that belongs elsewhere.
-          if gcloud run services describe "${PROD_SERVICE_NAME}" \
-               --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
-               --format='value(metadata.name)' >/dev/null 2>&1; then
-            echo "Service exists, rolling the image forward."
-            gcloud run services update "${PROD_SERVICE_NAME}" \
-              --image="${REF}" \
-              --project="${PROD_RUNTIME_PROJECT_ID}" \
-              --region="${CLOUD_RUN_REGION}" \
-              --update-labels="${LABELS}" \
-              --quiet
-          else
-            echo "Service absent, creating it (first promote into sml-website-prod)."
-            gcloud run deploy "${PROD_SERVICE_NAME}" \
-              --image="${REF}" \
-              --project="${PROD_RUNTIME_PROJECT_ID}" \
-              --region="${CLOUD_RUN_REGION}" \
-              --platform=managed \
-              --allow-unauthenticated \
-              --port=8080 \
-              --set-secrets=GEMINI_API_KEY=web-doc-gemini-api-key:latest \
-              --labels="${LABELS}" \
-              --quiet
-          fi
+          # Update only. The service definition (ingress, invoker, runtime SA,
+          # scaling, env) is owned by Terraform; anything set here would be
+          # invisible to it and read as unmanaged drift, and in prod would put
+          # the service on a bare run.app URL outside the load balancer.
+          gcloud run services update "${PROD_SERVICE_NAME}" \
+            --image="${REF}" \
+            --project="${PROD_RUNTIME_PROJECT_ID}" \
+            --region="${CLOUD_RUN_REGION}" \
+            --update-labels="${LABELS}" \
+            --quiet
 
       - name: Verify production serves
         run: |

--- a/.github/workflows/web-docs-promote.yml
+++ b/.github/workflows/web-docs-promote.yml
@@ -142,15 +142,34 @@ jobs:
             --update-labels="${LABELS}" \
             --quiet
 
-      - name: Verify production serves
+      - name: Verify the production revision converged
         run: |
           set -euo pipefail
-          URL="$(gcloud run services describe "${PROD_SERVICE_NAME}" \
-            --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
-            --format='value(status.url)')"
-          for i in $(seq 1 10); do
-            CODE="$(curl -s -o /dev/null -w '%{http_code}' "${URL}")"
-            [ "${CODE}" = "200" ] && { echo "OK ${URL}"; exit 0; }
-            echo "attempt ${i}: HTTP ${CODE}"; sleep 6
+          PROD_IMAGE="${ARTIFACT_REGION}-docker.pkg.dev/${PROD_ARTIFACT_PROJECT_ID}/${ARTIFACT_REPOSITORY}/${PROJECT_SLUG}"
+          EXPECTED="${PROD_IMAGE}@${{ steps.digest.outputs.digest }}"
+
+          # Prod sits behind the load balancer with internal ingress, so its
+          # run.app URL does not answer from a GitHub runner. Assert that Cloud
+          # Run reached a Ready revision serving the promoted digest instead.
+          for i in $(seq 1 30); do
+            READY="$(gcloud run services describe "${PROD_SERVICE_NAME}" \
+              --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+              --format='value(status.latestReadyRevisionName)')"
+            CREATED="$(gcloud run services describe "${PROD_SERVICE_NAME}" \
+              --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+              --format='value(status.latestCreatedRevisionName)')"
+            if [ -n "${READY}" ] && [ "${READY}" = "${CREATED}" ]; then
+              SERVING="$(gcloud run revisions describe "${READY}" \
+                --project="${PROD_RUNTIME_PROJECT_ID}" --region="${CLOUD_RUN_REGION}" \
+                --format='value(spec.containers[0].image)')"
+              if [ "${SERVING}" = "${EXPECTED}" ]; then
+                echo "OK ${READY} serving ${SERVING}"
+                exit 0
+              fi
+              echo "::error::${READY} serves ${SERVING}, expected ${EXPECTED}"
+              exit 1
+            fi
+            echo "attempt ${i}: created=${CREATED} ready=${READY}"
+            sleep 6
           done
-          echo "::error::${URL} never returned 200"; exit 1
+          echo "::error::no revision became ready in time"; exit 1


### PR DESCRIPTION
## What

Replaces the Cloud Build trigger that died with the `sml-web-doc-gen-dev` project. Mirrors the Chronax pipeline (Smlcrm/Chronax#107).

**`web-docs-dev.yml`** builds the docs on a push to `dev`:
- reads the Gemini key from Secret Manager at generate time, never baked into an image layer
- restores and saves the generation cache in GCS, so only changed modules go through Gemini
- pushes to `sml-web-doc-docker` in `sml-artifacts-dev` and deploys to `sml-website-dev`
- creates the Cloud Run service if absent, since the old one was destroyed with its project

**`web-docs-promote.yml`** ships prod by digest, gated on the `production` environment and authenticated as `github-ci-promote-prod`.

## Prerequisites still outstanding

All on Deni's side, verified live against GCP:

- `Smlcrm/TempusBench` is **not yet** bound to the promote-prod SA. Deni deliberately held this pending confirmation that TempusBench docs need their own promote job. They do: the docs live in this repo under `web-docs/` and ship to their own Cloud Run service, so no other repo can promote them.
- The `production` environment needs creating here, with reviewers. Owned by Deni, not me.
- Confirm `Smlcrm/TempusBench` is in `approved_cicd_repos` for the dev-side CI SA.
- `web-doc-gemini-api-key` does not exist in `sml-website-dev`, and Secret Manager API is not enabled on `sml-website-prod`.
- The CI SA needs object read/write on `gs://sml-website-dev-docgen-cache` (bucket created).

Do not merge ahead of the builder image, Smlcrm/web-doc-generator#1, or the first dev run will fail pulling `BUILDER_IMAGE`.