### PR TITLE
fix(ci): resolve ADC inside the docgen container

### DIFF
--- a/.github/workflows/web-docs-dev.yml
+++ b/.github/workflows/web-docs-dev.yml
@@ -69,14 +69,23 @@ jobs:
       - name: Generate the docs
         run: |
           set -euo pipefail
-          # RUNNER_TEMP is mounted at the same path inside the container so the
-          # ADC file written by google-github-actions/auth resolves, including
-          # the OIDC token file it points at. No credential is ever copied.
+          # ADC has to resolve INSIDE the container, and every path involved is
+          # an absolute HOST path: GOOGLE_APPLICATION_CREDENTIALS, and the OIDC
+          # token file named inside that credential file. So both directories
+          # google-github-actions/auth writes to are mounted at their original
+          # paths — the workspace (where the credential file actually lands)
+          # and RUNNER_TEMP — and the env var is passed through unchanged.
+          #
+          # Mounting the workspace only at /work is what broke this: the file
+          # was present, under a path the credential chain never looks at, so
+          # generation failed with DefaultCredentialsError after ingesting the
+          # whole repo. Read-only, and no credential is ever copied.
           docker run --rm \
             -e GOOGLE_APPLICATION_CREDENTIALS \
             -e GOOGLE_CLOUD_PROJECT \
             -e GOOGLE_CLOUD_LOCATION \
             -v "${RUNNER_TEMP}:${RUNNER_TEMP}:ro" \
+            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:ro" \
             -v "${PWD}:/work" \
             -v "${PWD}/.docgen-cache:/app/.docgen-cache" \
             "${BUILDER_IMAGE}" \


### PR DESCRIPTION
Same fix as Chronax #108. The docs pipeline's first real run fails on auth.

## What happened

Generation authenticates to Vertex through ADC, and every path in that chain is an absolute **host** path: `GOOGLE_APPLICATION_CREDENTIALS`, plus the OIDC token file named inside the credential file it points at.

`google-github-actions/auth` writes that credential file into the **workspace**, not `RUNNER_TEMP`. The workspace was mounted only at `/work`, so the file existed in the container under a path the credential chain never looks at.

The failure is late and misleading: the builder pulls, the repo ingests, and only the first Gemini call raises `DefaultCredentialsError` naming a host path.

## Fix

Mount the workspace at its original absolute path as well, read-only, so the env var passes through unchanged and both files resolve. No credential is copied.