### PR TITLE
Adapt pipeline to Tasks/ + Datasets/ catalog layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,11 @@ temp/
 
 hugging_face_upload_old/
 hugging_face_upload/.staging/
+hugging_face_upload/.staging_datasets_dev/
 
-# Task data hosted on Hugging Face (Smlcrm/tempus_bench_tasks); keep locally, not in git
+# Task definitions live in git under Tasks/; dataset CSVs sync from Hugging Face
+# (Smlcrm/tempus_bench_tasks Datasets/). Local Datasets/ is a runtime cache.
+Datasets/
 tempus_bench/tasks/
 
 # Local-only — data prep / smoke configs (do not commit)

--- a/tempus_bench/config/application_tasks_smoke.yaml
+++ b/tempus_bench/config/application_tasks_smoke.yaml
@@ -1,0 +1,23 @@
+# Smoke config for the application catalog layout (Tasks/ + Datasets/).
+#
+# Selectors use: {dataset_category}/{human task_name}
+# Also supported:
+#   - '*'                      all tasks in every catalog under Tasks/
+#   - 'commerce_and_trade/*'   all tasks in one category
+#
+# Example category glob (commented):
+#   # - commerce_and_trade/*
+evaluation:
+  task_paths:
+    - commerce_and_trade/Favorita Store 24 Weekly Sales
+    - natural_and_environmental_systems/Daily Humidity Time Series Data - Delhi
+    - energy_and_utilities/Weekly Cushing US
+  tuning_loss: mae
+  max_windows: 1
+  max_num_variates: 5
+  num_samples: 20
+  num_quantiles: 9
+  point_forecast_statistic: mean
+
+model:
+  naive_chronax: {}

--- a/tempus_bench/pipeline/data_loader.py
+++ b/tempus_bench/pipeline/data_loader.py
@@ -146,8 +146,12 @@ class DataLoader:
         self.task_config = task_config
         self.evaluation_config = evaluation_config
         self._force_no_normalize = force_no_normalize
-        task_path = Path(self.task_config.task_path)
-        self.dataset_path = task_path / self.task_config.file_name
+        from tempus_bench.utils.paths import get_dataset_path
+
+        self.dataset_path = get_dataset_path(
+            self.task_config.dataset_category,
+            self.task_config.dataset_name,
+        )
 
         self._load_dataset()
 

--- a/tempus_bench/pipeline/hyperparameter_tuner.py
+++ b/tempus_bench/pipeline/hyperparameter_tuner.py
@@ -27,7 +27,6 @@ from tempus_bench.utils.utils import compute_point_forecast
 from ..utils.configs import JobConfig
 from ..utils.log_manager import LogManager
 from ..utils.visualizer import Visualizer
-from ..utils.paths import get_task_path
 from .data_loader import DataLoader
 from .model_executor import ModelExecutor
 from .metric_registry import MetricRegistry
@@ -89,14 +88,11 @@ def _task_id_for_results_sink(task_config) -> str:
     """
     Task key for external sinks (e.g. BigQuery ``task_id`` / Firestore execution_plan).
 
-    Uses ``<family>/<task_name>`` after tasks/ (e.g. ``covariate/covariate_foo``);
-    falls back to task_name.
+    Uses ``{task_mode}/{task_name}`` (e.g. ``covariate/Favorita Store 24 Weekly Sales``).
     """
-    parts = Path(task_config.task_path).parts
-    for i, seg in enumerate(parts):
-        if seg.lower() == "tasks" and i + 1 < len(parts):
-            kind = parts[i + 1]
-            return f"{kind}/{task_config.task_name}"
+    mode = getattr(task_config, "task_mode", None)
+    if mode:
+        return f"{mode}/{task_config.task_name}"
     return task_config.task_name
 
 
@@ -150,8 +146,13 @@ class HyperparameterTuner:
 
         self.model_name = job_config.model_config.model_name
         self.tuning_loss = self.evaluation_config.tuning_loss
-        self.dataset_path = Path(self.task_config.task_path)
-        self.dataset_file_path = self.dataset_path / self.task_config.file_name
+        from tempus_bench.utils.paths import get_dataset_path
+
+        self.dataset_file_path = get_dataset_path(
+            self.task_config.dataset_category,
+            self.task_config.dataset_name,
+        )
+        self.dataset_path = self.dataset_file_path.parent
         self.visualizer = Visualizer()
 
     def _generate_hyperparameter_grid(self) -> List[dict]:

--- a/tempus_bench/utils/config_manager.py
+++ b/tempus_bench/utils/config_manager.py
@@ -31,9 +31,7 @@ from .model_settings import (
 from .paths import (
     get_project_root,
     get_models_dir,
-    find_task_directories,
 )
-from .task_yaml_loader import build_task_config
 
 
 class ValidationError(Exception):
@@ -160,30 +158,32 @@ class ConfigManager:
         """
         Initialize the tasks.
 
-        Discovers and loads all TaskConfig objects from task.yaml files in directories
-        found via find_task_directories using self.task_path.
+        Discovers and loads all TaskConfig objects from catalog YAML documents
+        under ``Tasks/`` matching ``evaluation.task_path`` / ``task_paths``.
 
         Returns:
-            Dict[str, TaskConfig]: Mapping of task directory names to their validated TaskConfig objects.
+            Dict[str, TaskConfig]: Mapping of human task names to TaskConfig objects.
 
         Raises:
-            FileNotFoundError or ValidationError if a task.yaml file is missing or invalid.
+            FileNotFoundError or ValidationError if task documents are missing or invalid.
         """
-        from tempus_bench.utils.task_assets import ensure_task_assets
+        from tempus_bench.utils.task_assets import ensure_dataset_assets
+        from tempus_bench.utils.paths import find_task_documents
+        from tempus_bench.utils.task_yaml_loader import build_task_config_from_raw
 
-        ensure_task_assets()
+        ensure_dataset_assets()
 
         task_configs = {}
         eval_config = self.evaluation_config
         if eval_config.task_paths:
-            tasks = {}
+            docs: dict = {}
             for p in eval_config.task_paths:
-                tasks.update(find_task_directories(p))
+                docs.update(find_task_documents(p))
         else:
-            tasks = find_task_directories(self.task_path)  # Dict[str, str]: name => path
+            docs = find_task_documents(self.task_path)
 
-        for task_name, task_path_str in tasks.items():
-            task_configs[task_name] = build_task_config(Path(task_path_str))
+        for task_name, raw in docs.items():
+            task_configs[task_name] = build_task_config_from_raw(raw)
 
         return task_configs
 
@@ -272,7 +272,10 @@ class ConfigManager:
             for task_name, tc in self.task_configs.items():
                 try:
                     assert_model_supports_task_family(
-                        cap, model_name=model_name, family=tc.task_mode
+                        cap,
+                        model_name=model_name,
+                        family=tc.task_mode,
+                        num_targets=len(tc.target_variable_names),
                     )
                 except ValueError as e:
                     raise ValidationError(

--- a/tempus_bench/utils/configs.py
+++ b/tempus_bench/utils/configs.py
@@ -176,15 +176,31 @@ class DatasetConfig(BaseModel):
 
 class TaskConfig(BaseModel):
     """
-    Task configuration for tasks benchmark folders.
+    Task configuration for catalog tasks under ``Tasks/``.
 
-    Supports univariate, multivariate, and covariate task folders under tasks/.
+    Mode is inferred from target/covariate lists. Dataset CSVs resolve via
+    ``dataset_category`` / ``dataset_name`` under repo-root ``Datasets/``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    task_name: str = Field(..., description="Task folder name (basename of task_path)")
-    task_path: str = Field(..., description="On-disk task directory path")
+    task_name: str = Field(..., description="Human-readable task name")
+    task_path: str = Field(
+        ...,
+        description="Logical selector '{dataset_category}/{task_name}'",
+    )
+    task_description: str = Field(
+        default="", description="Human-readable task description from catalog YAML"
+    )
+    task_catalog: str = Field(
+        default="application", description="Catalog id (e.g. application)"
+    )
+    dataset_category: str = Field(
+        ..., description="Domain category folder under Datasets/"
+    )
+    dataset_name: str = Field(
+        ..., description="Dataset slug / folder name under Datasets/{category}/"
+    )
     forecast_horizon: int = Field(
         ..., ge=1, le=128, description="Number of steps to forecast ahead (max 128)"
     )
@@ -198,7 +214,10 @@ class TaskConfig(BaseModel):
         default="standard",
         description="Normalization applied to targets during preprocessing",
     )
-    file_name: str = Field(..., description="Dataset CSV file name inside task_path")
+    file_name: str = Field(
+        ...,
+        description="Dataset CSV file name ({dataset_name}.csv); kept for legacy call sites",
+    )
     task_mode: Literal["univariate", "multivariate", "covariate"] = Field(
         ..., description="Evaluation mode for this logical task"
     )

--- a/tempus_bench/utils/model_settings.py
+++ b/tempus_bench/utils/model_settings.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import copy
 from functools import lru_cache
-from pathlib import Path
 from typing import Any, Literal
 
 import yaml
@@ -164,28 +163,13 @@ def merge_benchmark_params_with_default_grid(
 
 
 def task_path_to_family(task_path: str, task_mode: str | None = None) -> TaskFamily:
-    """Infer task family from explicit mode or dataset path under tasks/."""
+    """Infer task family from explicit mode (preferred) or legacy path markers."""
     if task_mode in ("univariate", "multivariate", "covariate"):
         return task_mode  # type: ignore[return-value]
-    p = Path(task_path).resolve()
-    parts = p.parts
-    for marker in ("tasks",):
-        try:
-            i = parts.index(marker)
-            kind = parts[i + 1].lower()
-            break
-        except (ValueError, IndexError):
-            kind = None
-    else:
-        raise ValueError(f"Cannot infer task family from path: {task_path!r}")
-    if kind == "univariate":
-        return "univariate"
-    if kind == "multivariate":
-        return "multivariate"
-    if kind == "covariate":
-        return "covariate"
+    # Logical selectors are "{category}/{task_name}" and do not encode family.
     raise ValueError(
-        f"Unknown task family {kind!r} under tasks/ in path: {task_path!r}"
+        f"Cannot infer task family from path {task_path!r} without task_mode. "
+        "Pass task_mode from TaskConfig."
     )
 
 
@@ -194,6 +178,7 @@ def assert_model_supports_task_family(
     *,
     model_name: str,
     family: TaskFamily,
+    num_targets: int = 1,
 ) -> None:
     if family == "univariate" and not cap.univariate:
         raise ValueError(
@@ -209,6 +194,11 @@ def assert_model_supports_task_family(
         raise ValueError(
             f"Model {model_name!r} is not declared for covariate tasks "
             f"(capabilities.covariates: none)."
+        )
+    if family == "covariate" and num_targets > 1 and not cap.multivariate:
+        raise ValueError(
+            f"Model {model_name!r} is not declared for multi-target covariate tasks "
+            f"(capabilities.multivariate: false, num_targets={num_targets})."
         )
 
 

--- a/tempus_bench/utils/paths.py
+++ b/tempus_bench/utils/paths.py
@@ -1,13 +1,16 @@
 """
 Path utilities for inferring absolute paths from the project structure.
 
-This module provides utilities to infer absolute paths based on the fixed
-project structure, eliminating the need for directory path configuration.
+Discovers catalog tasks under repo-root ``Tasks/`` and resolves dataset CSVs
+under repo-root ``Datasets/``.
 """
 
-import os
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
+from typing import Any
+
+import yaml
 
 
 def get_project_root() -> Path:
@@ -17,31 +20,175 @@ def get_project_root() -> Path:
     Returns:
         Path: Absolute path to the project root
     """
-    # Get the directory containing this file (tempus_bench/utils/)
     current_file = Path(__file__).resolve()
-    # Go up two levels to reach project root
     return current_file.parent.parent.parent
 
 
 def get_tasks_dir() -> Path:
     """
-    Get the absolute path to the tasks directory.
-
-    Downloads task CSV data from Hugging Face on first use when files are missing.
+    Get the absolute path to the catalog task definitions directory.
 
     Returns:
-        Path: Absolute path to tempus_bench/tasks/
+        Path: Absolute path to repo-root ``Tasks/``
 
     Raises:
-        FileNotFoundError: If the tasks directory doesn't exist
+        FileNotFoundError: If the Tasks directory doesn't exist
     """
-    from tempus_bench.utils.task_assets import ensure_task_assets
-
-    ensure_task_assets()
-    tasks_dir = get_project_root() / "tempus_bench" / "tasks"
-    if not tasks_dir.exists():
+    tasks_dir = get_project_root() / "Tasks"
+    if not tasks_dir.is_dir():
         raise FileNotFoundError(f"Tasks directory not found: {tasks_dir}")
     return tasks_dir
+
+
+def get_datasets_dir(*, ensure: bool = True) -> Path:
+    """
+    Get the absolute path to the local Datasets directory.
+
+    When ``ensure`` is True, syncs missing CSVs from Hugging Face once per process.
+
+    Returns:
+        Path: Absolute path to repo-root ``Datasets/``
+    """
+    if ensure:
+        from tempus_bench.utils.task_assets import ensure_dataset_assets
+
+        ensure_dataset_assets()
+    return get_project_root() / "Datasets"
+
+
+def list_task_catalog_dirs() -> list[Path]:
+    """Return immediate catalog directories under ``Tasks/`` (e.g. Application Tasks)."""
+    tasks_dir = get_tasks_dir()
+    return sorted(
+        p
+        for p in tasks_dir.iterdir()
+        if p.is_dir() and not p.name.startswith(".") and not p.name.startswith("__")
+    )
+
+
+def _iter_category_yaml_files() -> list[Path]:
+    files: list[Path] = []
+    for catalog_dir in list_task_catalog_dirs():
+        files.extend(sorted(catalog_dir.glob("*.yaml")))
+        files.extend(sorted(catalog_dir.glob("*.yml")))
+    return files
+
+
+def load_all_task_documents() -> list[dict[str, Any]]:
+    """
+    Load every ``task:`` document from all catalog YAML files under ``Tasks/``.
+
+    Raises:
+        ValueError: On duplicate human ``task_name`` values across the catalog.
+        ValueError: If a document uses singular ``target_variable_name``.
+    """
+    docs: list[dict[str, Any]] = []
+    seen_names: dict[str, str] = {}
+
+    for yaml_path in _iter_category_yaml_files():
+        with yaml_path.open(encoding="utf-8") as handle:
+            raw_docs = list(yaml.safe_load_all(handle))
+        for doc in raw_docs:
+            if not doc or "task" not in doc:
+                continue
+            task = doc["task"]
+            if not isinstance(task, dict):
+                raise ValueError(f"Invalid task document in {yaml_path}")
+            if "target_variable_name" in task:
+                raise ValueError(
+                    f"Singular 'target_variable_name' is not allowed in {yaml_path} "
+                    f"(task_name={task.get('task_name')!r}). Use only 'target_variable_names'."
+                )
+            name = task.get("task_name")
+            if not name or not isinstance(name, str):
+                raise ValueError(f"Missing task_name in {yaml_path}")
+            if name in seen_names:
+                raise ValueError(
+                    f"Duplicate task_name {name!r}: seen in {seen_names[name]} and {yaml_path}"
+                )
+            seen_names[name] = str(yaml_path)
+            enriched = dict(task)
+            enriched["_source_yaml"] = str(yaml_path)
+            docs.append(enriched)
+    return docs
+
+
+def find_task_documents(task_path_pattern: str) -> dict[str, dict[str, Any]]:
+    """
+    Find task documents matching a selector under ``Tasks/``.
+
+    Supported patterns:
+    - ``*``: all tasks in every catalog
+    - ``{dataset_category}/*``: all tasks in that category
+    - ``{dataset_category}/{human task_name}``: one exact task
+
+    Returns:
+        Mapping of human ``task_name`` -> raw task document dict.
+    """
+    pattern = task_path_pattern.strip()
+    all_docs = load_all_task_documents()
+    matched: dict[str, dict[str, Any]] = {}
+
+    if pattern == "*":
+        for doc in all_docs:
+            matched[doc["task_name"]] = doc
+        return matched
+
+    if pattern.endswith("/*"):
+        category = pattern[:-2]
+        for doc in all_docs:
+            if doc.get("dataset_category") == category:
+                matched[doc["task_name"]] = doc
+        return matched
+
+    if "/" not in pattern:
+        raise ValueError(
+            f"Invalid task selector {pattern!r}. Expected '*', "
+            "'{category}/*', or '{category}/{task_name}'."
+        )
+
+    category, _, task_name = pattern.partition("/")
+    for doc in all_docs:
+        if doc.get("dataset_category") == category and doc.get("task_name") == task_name:
+            matched[doc["task_name"]] = doc
+            return matched
+    return matched
+
+
+def find_task_directories(task_path_pattern: str) -> dict[str, str]:
+    """
+    Backward-compatible discovery API.
+
+    Returns mapping of human ``task_name`` -> logical selector
+    ``{dataset_category}/{task_name}``. Prefer ``find_task_documents`` for
+    loading full YAML payloads.
+    """
+    docs = find_task_documents(task_path_pattern)
+    return {
+        name: f"{doc['dataset_category']}/{doc['task_name']}"
+        for name, doc in docs.items()
+    }
+
+
+def get_dataset_path(
+    dataset_category: str,
+    dataset_name: str,
+    *,
+    ensure: bool = True,
+) -> Path:
+    """
+    Resolve ``Datasets/{dataset_category}/{dataset_name}/{dataset_name}.csv``.
+
+    Raises:
+        FileNotFoundError: If the CSV is missing after optional HF sync.
+    """
+    datasets_root = get_datasets_dir(ensure=ensure)
+    dataset_path = (
+        datasets_root / dataset_category / dataset_name / f"{dataset_name}.csv"
+    )
+    if not dataset_path.is_file():
+        raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
+    return dataset_path
 
 
 def get_models_dir() -> Path:
@@ -64,117 +211,40 @@ def get_available_models() -> set:
     """
     Get all available model names from the models directory structure.
 
-    This function scans the models directory to find all model folders that contain
-    a corresponding model file. The model file naming convention is {model_name}_model.py.
-
     Returns:
         set: Set of available model names found in the models directory
     """
     available_models = set()
     models_dir = get_models_dir()
-    # Look for model folders directly in the models directory
     for model_folder in models_dir.iterdir():
         if (
             model_folder.is_dir()
             and not model_folder.name.startswith("__")
             and not model_folder.name.startswith(".")
         ):
-            # Check if it has a model file
             model_file = model_folder / f"{model_folder.name}_model.py"
             settings_file = model_folder / "settings.yaml"
             if model_file.exists() and settings_file.exists():
                 available_models.add(model_folder.name)
-
     return available_models
 
 
 def get_absolute_runs_dir(runs_dir_relative: str) -> Path:
-    """
-    Get the absolute path to the runs directory from a relative path.
-
-    Args:
-        runs_dir_relative: Relative path to runs directory (e.g., "runs")
-
-    Returns:
-        Path: Absolute path to runs directory
-    """
+    """Get the absolute path to the runs directory from a relative path."""
     runs_path = Path(runs_dir_relative)
     if runs_path.is_absolute():
         return runs_path
     return get_project_root() / runs_dir_relative
 
 
-def get_task_path(task_name: str) -> Path:
-    """
-    Get the absolute path to a specific task directory.
-
-    Args:
-        task_name: Name of the task (e.g., 'multivariate/multivariate_transport_monthly_airline_baggage_complaints')
-
-    Returns:
-        Path: Absolute path to the task directory
-
-    Raises:
-        FileNotFoundError: If the task directory doesn't exist
-    """
-    task_path = get_tasks_dir() / task_name
-    if not task_path.exists():
-        raise FileNotFoundError(f"Task directory not found: {str(task_path)}")
-    return task_path
-
-
-def get_dataset_path(task_name: str, *, file_name: str | None = None) -> Path:
-    """
-    Get the absolute path to a task dataset CSV.
-
-    Args:
-        task_name: Relative task path (e.g. ``univariate/foo`` or ``multivariate/bar``).
-        file_name: CSV filename from task.yaml; when omitted, tries ``{basename}.csv``
-            then the sole ``*.csv`` in the task folder.
-
-    Returns:
-        Path: Absolute path to the dataset file
-
-    Raises:
-        FileNotFoundError: If the dataset file doesn't exist
-    """
-    task_dir = get_task_path(task_name)
-    if file_name:
-        dataset_path = task_dir / file_name
-    else:
-        primary = task_dir / f"{task_dir.name}.csv"
-        if primary.exists():
-            dataset_path = primary
-        else:
-            csv_files = sorted(task_dir.glob("*.csv"))
-            if len(csv_files) == 1:
-                dataset_path = csv_files[0]
-            else:
-                dataset_path = primary
-    if not dataset_path.exists():
-        raise FileNotFoundError(f"Dataset file not found: {dataset_path}")
-    return dataset_path
-
-
 def get_model_path(model_type: str, model_name: str) -> Path:
     """
     Get the absolute path to a specific model directory.
 
-    Args:
-        model_type: Type of model ('deterministic', 'stochastic', or 'hybrid') - deprecated, kept for backwards compatibility
-        model_name: Name of the model
-
-    Returns:
-        Path: Absolute path to the model directory
-
-    Raises:
-        FileNotFoundError: If the model directory doesn't exist
-
     Note:
-        The model_type parameter is deprecated as models are now organized by their
-        settings.yaml file rather than folder structure. It's kept for backwards compatibility.
+        ``model_type`` is deprecated and ignored.
     """
-    # Models are now directly in the models directory, not in subdirectories
+    del model_type
     model_path = get_models_dir() / model_name
     if not model_path.exists():
         raise FileNotFoundError(f"Model directory not found: {model_path}")
@@ -182,15 +252,7 @@ def get_model_path(model_type: str, model_name: str) -> Path:
 
 
 def get_runs_dir() -> Path:
-    """
-    Get the absolute path to the runs directory.
-
-    Returns:
-        Path: Absolute path to runs directory
-
-    Raises:
-        FileNotFoundError: If the runs directory doesn't exist
-    """
+    """Get the absolute path to the runs directory."""
     runs_dir = get_project_root() / "runs"
     if not runs_dir.exists():
         raise FileNotFoundError(f"Runs directory not found: {runs_dir}")
@@ -198,61 +260,12 @@ def get_runs_dir() -> Path:
 
 
 def get_logs_path() -> Path:
-    """
-    Get the absolute path to the project logs directory (may not exist yet).
-
-    Returns:
-        Path: Absolute path to ``<project_root>/logs``
-    """
+    """Get the absolute path to the project logs directory (may not exist yet)."""
     return get_project_root() / "logs"
 
 
-def find_task_directories(task_path_pattern: str) -> dict[str, str]:
-    """
-    Find task directories based on a task path pattern under tasks/.
-
-    Supported patterns:
-    - ``*``: all folders under univariate/, multivariate/, and covariate/
-    - ``univariate/*`` / ``multivariate/*`` / ``covariate/*``: all folders in that category
-    - ``univariate/foo`` / ``multivariate/foo`` / ``covariate/foo``
-    """
-    tasks_dir = get_tasks_dir()
-    task_paths: dict[str, str] = {}
-    pattern = task_path_pattern.strip()
-
-    def _register_folder(task_path: Path) -> None:
-        if task_path.is_dir():
-            task_paths[task_path.name] = str(task_path)
-
-    if pattern == "*":
-        for subdir_name in ("univariate", "multivariate", "covariate"):
-            subdir_path = tasks_dir / subdir_name
-            if not subdir_path.is_dir():
-                continue
-            for task_path in subdir_path.iterdir():
-                _register_folder(task_path)
-        return task_paths
-
-    if pattern.endswith("/*"):
-        subdir_name = pattern[:-2]
-        subdir_path = tasks_dir / subdir_name
-        if subdir_path.is_dir():
-            for task_path in subdir_path.iterdir():
-                _register_folder(task_path)
-        return task_paths
-
-    task_path = tasks_dir / pattern
-    _register_folder(task_path)
-    return task_paths
-
-
 def ensure_directory_exists(path: Path) -> None:
-    """
-    Ensure that a directory exists, creating it if necessary.
-
-    Args:
-        path: Path to the directory to ensure exists
-    """
+    """Ensure that a directory exists, creating it if necessary."""
     path.mkdir(parents=True, exist_ok=True)
 
 
@@ -260,30 +273,19 @@ def get_available_metrics() -> list[Path]:
     """
     Get all files containing subclasses of the BaseMetric class.
 
-    This function scans the metrics directory for Python files and assumes all files
-    (except base_metric.py, __init__.py, and cache files) contain BaseMetric subclasses.
-
     Returns:
         list[Path]: List of absolute file paths containing BaseMetric subclasses
-
-    Raises:
-        FileNotFoundError: If the metrics directory doesn't exist
     """
-    # Get the absolute path to the metrics directory
     metrics_dir = get_project_root() / "tempus_bench" / "metrics"
     if not metrics_dir.exists():
         raise FileNotFoundError(f"Metrics directory not found: {metrics_dir}")
 
     metric_files = []
-
-    # Scan all Python files in the metrics directory
     for file_path in metrics_dir.glob("*.py"):
-        # Skip files starting with "." or "__", and base_metric.py
         if (
             not file_path.name.startswith(".")
             and not file_path.name.startswith("__")
             and file_path.name != "base_metric.py"
         ):
             metric_files.append(file_path.resolve())
-
     return metric_files

--- a/tempus_bench/utils/task_assets.py
+++ b/tempus_bench/utils/task_assets.py
@@ -1,8 +1,9 @@
 """
-Ensure TempusBench task data is present locally by downloading from Hugging Face.
+Ensure TempusBench dataset CSVs are present locally by syncing from Hugging Face.
 
-Task CSVs (and optionally the full ``tempus_bench/tasks/`` tree) are hosted at
-``Smlcrm/tempus_bench_tasks`` so the git repository stays lightweight.
+Task definitions live in git under ``Tasks/``. Dataset CSVs are hosted at
+``Smlcrm/tempus_bench_tasks`` under ``Datasets/`` and synced into repo-root
+``Datasets/`` once at benchmark start.
 """
 
 from __future__ import annotations
@@ -10,100 +11,93 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
-import yaml
 from tqdm import tqdm
 
-from tempus_bench.utils.paths import get_project_root
+from tempus_bench.utils.paths import get_project_root, load_all_task_documents
 
 TASKS_REPO_ID = os.environ.get("TEMPUS_BENCH_TASKS_REPO_ID", "Smlcrm/tempus_bench_tasks")
+DATASETS_REVISION = os.environ.get("TEMPUS_BENCH_DATASETS_REVISION", "dev")
 SKIP_DOWNLOAD_ENV = "TEMPUS_BENCH_SKIP_TASK_DOWNLOAD"
-HF_TASKS_PREFIX = "tasks"
-CATEGORIES = ("univariate", "multivariate", "covariate")
+SKIP_DATASET_SYNC_ENV = "TEMPUS_BENCH_SKIP_DATASET_SYNC"
+HF_DATASETS_PREFIX = "Datasets"
 
 _ensured = False
 
 
 @dataclass(frozen=True)
-class TaskAssetSpec:
-    """One task file expected under ``tempus_bench/tasks/``."""
+class DatasetAssetSpec:
+    """One dataset CSV expected under repo-root ``Datasets/``."""
 
-    category: str
-    folder_name: str
-    file_name: str
+    dataset_category: str
+    dataset_name: str
     local_path: Path
-    hf_path: str  # repo-relative posix path
+    hf_path: str
 
 
-def _tasks_root() -> Path:
-    return get_project_root() / "tempus_bench" / "tasks"
+def _datasets_root() -> Path:
+    return get_project_root() / "Datasets"
 
 
-def _load_task_block(task_yaml: Path) -> dict:
-    with task_yaml.open(encoding="utf-8") as handle:
-        docs = list(yaml.safe_load_all(handle))
-    for doc in docs:
-        if doc and isinstance(doc, dict) and "task" in doc:
-            return doc["task"]
-    raise ValueError(f"No 'task:' block found in {task_yaml}")
+def discover_expected_datasets() -> list[DatasetAssetSpec]:
+    """Build expected dataset inventory from catalog task YAMLs under ``Tasks/``."""
+    root = _datasets_root()
+    specs: list[DatasetAssetSpec] = []
+    seen: set[tuple[str, str]] = set()
 
-
-def discover_expected_assets(tasks_root: Path | None = None) -> list[TaskAssetSpec]:
-    """
-    Discover per-task CSV assets from local ``task.yaml`` files.
-
-    Returns an empty list when no task definitions exist locally (fresh clone).
-    """
-    root = tasks_root or _tasks_root()
-    specs: list[TaskAssetSpec] = []
-
-    if not root.is_dir():
-        return specs
-
-    for category in CATEGORIES:
-        cat_dir = root / category
-        if not cat_dir.is_dir():
+    for doc in load_all_task_documents():
+        category = doc["dataset_category"]
+        name = doc["dataset_name"]
+        key = (category, name)
+        if key in seen:
             continue
-        for task_dir in sorted(cat_dir.iterdir(), key=lambda p: p.name.lower()):
-            if not task_dir.is_dir():
-                continue
-            task_yaml = task_dir / "task.yaml"
-            if not task_yaml.is_file():
-                continue
-            block = _load_task_block(task_yaml)
-            dataset = block.get("dataset") or {}
-            file_name = dataset.get("file_name")
-            if not file_name:
-                file_name = block.get("file_name")
-            if not file_name:
-                raise ValueError(f"Missing dataset.file_name in {task_yaml}")
-
-            folder = task_dir.name
-            local_csv = task_dir / file_name
-            hf_path = f"{HF_TASKS_PREFIX}/{category}/{folder}/{file_name}".replace("\\", "/")
-            specs.append(
-                TaskAssetSpec(
-                    category=category,
-                    folder_name=folder,
-                    file_name=file_name,
-                    local_path=local_csv,
-                    hf_path=hf_path,
-                )
+        seen.add(key)
+        local_csv = root / category / name / f"{name}.csv"
+        hf_path = f"{HF_DATASETS_PREFIX}/{category}/{name}/{name}.csv".replace("\\", "/")
+        specs.append(
+            DatasetAssetSpec(
+                dataset_category=category,
+                dataset_name=name,
+                local_path=local_csv,
+                hf_path=hf_path,
             )
+        )
     return specs
 
 
-def _missing_assets(specs: list[TaskAssetSpec]) -> list[TaskAssetSpec]:
+def _missing_assets(specs: list[DatasetAssetSpec]) -> list[DatasetAssetSpec]:
     return [spec for spec in specs if not spec.local_path.is_file()]
 
 
-def _skip_download_enabled() -> bool:
-    return os.environ.get(SKIP_DOWNLOAD_ENV, "").strip().lower() in {"1", "true", "yes"}
+def _skip_sync_enabled() -> bool:
+    for env_name in (SKIP_DATASET_SYNC_ENV, SKIP_DOWNLOAD_ENV):
+        if os.environ.get(env_name, "").strip().lower() in {"1", "true", "yes"}:
+            return True
+    return False
 
 
-def _download_file(repo_id: str, hf_path: str, dest: Path) -> None:
+def _list_remote_dataset_csv_paths(repo_id: str, revision: str) -> set[str]:
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    items = api.list_repo_tree(
+        repo_id,
+        repo_type="dataset",
+        revision=revision,
+        recursive=True,
+    )
+    paths: set[str] = set()
+    for item in items:
+        path = getattr(item, "path", None) or str(item)
+        if path.endswith(".csv") and path.startswith(f"{HF_DATASETS_PREFIX}/"):
+            paths.add(path.replace("\\", "/"))
+    return paths
+
+
+def _download_file(repo_id: str, revision: str, hf_path: str, dest: Path) -> None:
     from huggingface_hub import hf_hub_download
 
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -111,112 +105,111 @@ def _download_file(repo_id: str, hf_path: str, dest: Path) -> None:
         repo_id=repo_id,
         filename=hf_path,
         repo_type="dataset",
+        revision=revision,
     )
     shutil.copy2(cached, dest)
 
 
-def _download_snapshot(repo_id: str, tasks_root: Path) -> None:
-    from huggingface_hub import snapshot_download
-
-    project_root = get_project_root()
-    package_root = project_root / "tempus_bench"
-    snapshot_download(
-        repo_id=repo_id,
-        repo_type="dataset",
-        local_dir=str(package_root),
-        allow_patterns=[f"{HF_TASKS_PREFIX}/**"],
-    )
-    if not tasks_root.is_dir():
-        # Recover from older downloads that used project_root as local_dir.
-        misplaced = project_root / HF_TASKS_PREFIX
-        if misplaced.is_dir():
-            package_root.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(misplaced), str(tasks_root))
-    if not tasks_root.is_dir():
-        raise FileNotFoundError(
-            f"Download completed but tasks directory is still missing: {tasks_root}"
-        )
-
-
-def ensure_task_assets(*, force: bool = False) -> None:
+def ensure_dataset_assets(*, force: bool = False) -> None:
     """
-    Ensure task CSV files exist under ``tempus_bench/tasks/``.
+    Ensure expected dataset CSVs exist under repo-root ``Datasets/``.
 
-    When files are missing, downloads them from the public Hugging Face dataset
-    with an explanatory message and a progress bar.
-
-    Args:
-        force: Re-check even if a prior call succeeded in this process.
+    Once per process (unless ``force``):
+    1. Build expected inventory from ``Tasks/``
+    2. Compare to local ``Datasets/``
+    3. Auto-download missing files from HF
+    4. Fail if HF is unreachable and any expected CSV is missing
     """
     global _ensured
     if _ensured and not force:
         return
 
-    tasks_root = _tasks_root()
-    specs = discover_expected_assets(tasks_root)
+    specs = discover_expected_datasets()
+    if not specs:
+        raise FileNotFoundError(
+            "No task documents found under Tasks/. Add catalog YAML files before running."
+        )
+
     missing = _missing_assets(specs)
-
-    if not missing and tasks_root.is_dir() and specs:
+    if not missing:
+        _warn_extra_local(specs)
         _ensured = True
         return
 
-    if _skip_download_enabled():
-        if not tasks_root.is_dir() or missing:
-            missing_paths = [str(s.local_path) for s in missing]
-            raise FileNotFoundError(
-                "Task data is not available locally and automatic download is disabled "
-                f"({SKIP_DOWNLOAD_ENV} is set). Missing: {missing_paths or [str(tasks_root)]}. "
-                f"Unset {SKIP_DOWNLOAD_ENV} or run: "
-                f"python hugging_face_upload/upload_dataset.py --repo-id {TASKS_REPO_ID}"
-            )
-        _ensured = True
-        return
+    if _skip_sync_enabled():
+        missing_paths = [str(s.local_path) for s in missing]
+        raise FileNotFoundError(
+            "Dataset CSVs are missing locally and automatic sync is disabled "
+            f"({SKIP_DATASET_SYNC_ENV}/{SKIP_DOWNLOAD_ENV}). Missing: {missing_paths}."
+        )
 
     repo_id = TASKS_REPO_ID
-    dataset_url = f"https://huggingface.co/datasets/{repo_id}"
-
-    if not specs:
-        print(
-            f"\n[TempusBench] Task definitions not found under {tasks_root}.\n"
-            f"  Task data is hosted on Hugging Face to keep the repository lightweight.\n"
-            f"  Dataset: {dataset_url}\n"
-            f"  Downloading the tasks folder now...\n",
-            flush=True,
-        )
-        _download_snapshot(repo_id, tasks_root)
-        specs = discover_expected_assets(tasks_root)
-        missing = _missing_assets(specs)
-        if missing:
-            missing_list = ", ".join(s.hf_path for s in missing)
-            raise FileNotFoundError(
-                f"Tasks folder downloaded but CSV assets are still missing: {missing_list}"
-            )
-        print("[TempusBench] Task data download complete.\n", flush=True)
-        _ensured = True
-        return
-
-    if not missing:
-        _ensured = True
-        return
+    revision = DATASETS_REVISION
+    dataset_url = f"https://huggingface.co/datasets/{repo_id}/tree/{revision}"
 
     print(
-        f"\n[TempusBench] Task CSV data is hosted on Hugging Face ({repo_id}) "
-        f"to keep the git repository lightweight.\n"
+        f"\n[TempusBench] Dataset CSVs are hosted on Hugging Face ({repo_id}@{revision}).\n"
         f"  Dataset: {dataset_url}\n"
-        f"  {len(missing)} of {len(specs)} task CSV file(s) missing locally; downloading now...\n",
+        f"  {len(missing)} of {len(specs)} CSV file(s) missing locally; syncing now...\n",
         flush=True,
     )
 
-    for spec in tqdm(missing, desc="Downloading task CSVs", unit="file", file=sys.stdout):
-        _download_file(repo_id, spec.hf_path, spec.local_path)
+    try:
+        remote_csvs = _list_remote_dataset_csv_paths(repo_id, revision)
+    except Exception as exc:
+        missing_paths = [str(s.local_path) for s in missing]
+        raise FileNotFoundError(
+            "Hugging Face is unreachable and required dataset CSVs are missing locally. "
+            f"Missing: {missing_paths}. Error: {exc}"
+        ) from exc
+
+    expected_hf = {s.hf_path for s in specs}
+    remote_missing = sorted(expected_hf - remote_csvs)
+    if remote_missing:
+        raise FileNotFoundError(
+            f"Remote dataset inventory is incomplete on {repo_id}@{revision}. "
+            f"Missing on Hub: {remote_missing}"
+        )
+
+    for spec in tqdm(missing, desc="Downloading dataset CSVs", unit="file", file=sys.stdout):
+        try:
+            _download_file(repo_id, revision, spec.hf_path, spec.local_path)
+        except Exception as exc:
+            raise FileNotFoundError(
+                f"Failed to download {spec.hf_path} from {repo_id}@{revision}: {exc}"
+            ) from exc
 
     still_missing = _missing_assets(specs)
     if still_missing:
         paths = ", ".join(str(s.local_path) for s in still_missing)
-        raise FileNotFoundError(f"Failed to download task CSV(s): {paths}")
+        raise FileNotFoundError(f"Failed to download dataset CSV(s): {paths}")
 
-    print("[TempusBench] Task data download complete.\n", flush=True)
+    _warn_extra_local(specs)
+    print("[TempusBench] Dataset sync complete.\n", flush=True)
     _ensured = True
+
+
+def _warn_extra_local(specs: list[DatasetAssetSpec]) -> None:
+    root = _datasets_root()
+    if not root.is_dir():
+        return
+    expected = {s.local_path.resolve() for s in specs}
+    extras: list[str] = []
+    for path in root.rglob("*.csv"):
+        if path.resolve() not in expected:
+            extras.append(str(path.relative_to(root)))
+    if extras:
+        warnings.warn(
+            "Local Datasets/ contains CSV files not referenced by Tasks/: "
+            + ", ".join(sorted(extras)[:20])
+            + (" ..." if len(extras) > 20 else ""),
+            stacklevel=2,
+        )
+
+
+def ensure_task_assets(*, force: bool = False) -> None:
+    """Backward-compatible alias for ``ensure_dataset_assets``."""
+    ensure_dataset_assets(force=force)
 
 
 def reset_ensure_cache() -> None:

--- a/tempus_bench/utils/task_yaml_loader.py
+++ b/tempus_bench/utils/task_yaml_loader.py
@@ -1,131 +1,87 @@
-"""Load tasks task.yaml files into TaskConfig objects."""
+"""Load catalog task YAML documents into TaskConfig objects."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
-
-import yaml
+from typing import Any, Literal
 
 from tempus_bench.utils.configs import TaskConfig
 
-HandleMissing = Literal[
-    "interpolate", "mean", "median", "drop", "forward_fill", "backward_fill"
-]
-NormalizationMethod = Literal["standard", "none"]
 TaskMode = Literal["univariate", "multivariate", "covariate"]
 
 
-def _task_kind(task_dir: Path) -> str:
-    parts = task_dir.resolve().parts
-    for marker in ("tasks",):
-        try:
-            idx = parts.index(marker)
-            return parts[idx + 1].lower()
-        except (ValueError, IndexError):
-            continue
-    raise ValueError(f"Cannot infer task kind from path: {task_dir}")
+def infer_task_mode(
+    target_variable_names: list[str],
+    covariate_variable_names: list[str],
+) -> TaskMode:
+    """Infer evaluation mode from target/covariate lists."""
+    n_targets = len(target_variable_names)
+    n_covariates = len(covariate_variable_names)
+    if n_targets < 1:
+        raise ValueError("target_variable_names must contain at least one name")
+    if n_covariates > 0:
+        return "covariate"
+    if n_targets == 1:
+        return "univariate"
+    return "multivariate"
 
 
-def _read_task_documents(task_dir: Path) -> list[dict]:
-    yaml_path = task_dir / "task.yaml"
-    if not yaml_path.is_file():
-        raise FileNotFoundError(f"Missing task.yaml: {yaml_path}")
-    with yaml_path.open(encoding="utf-8") as handle:
-        documents = list(yaml.safe_load_all(handle))
-    payloads = [doc["task"] for doc in documents if doc and "task" in doc]
-    if not payloads:
-        raise ValueError(f"No valid task document in {yaml_path}")
-    return payloads
-
-
-def _base_fields(raw: dict, *, task_name: str, task_path: str, task_mode: TaskMode) -> dict:
-    return {
-        "task_name": task_name,
-        "task_path": task_path,
-        "context_window": raw["context_window"],
-        "forecast_horizon": raw["forecast_horizon"],
-        "handle_missing": raw.get("handle_missing", "interpolate"),
-        "normalization_method": raw.get("normalization_method", "standard"),
-        "file_name": raw["file_name"],
-        "task_mode": task_mode,
-    }
-
-
-def _build_univariate_config(raw: dict, *, task_name: str, task_path: str) -> TaskConfig:
-    target_names = list(raw["target_variable_names"])
-    return TaskConfig(
-        **_base_fields(
-            raw,
-            task_name=task_name,
-            task_path=task_path,
-            task_mode="univariate",
-        ),
-        target_variable_names=target_names,
-        covariate_variable_names=[],
-    )
-
-
-def _build_multivariate_config(raw: dict, *, task_name: str, task_path: str) -> TaskConfig:
-    all_names = list(raw["target_variable_names"])
-    return TaskConfig(
-        **_base_fields(
-            raw,
-            task_name=task_name,
-            task_path=task_path,
-            task_mode="multivariate",
-        ),
-        target_variable_names=all_names,
-        covariate_variable_names=[],
-    )
-
-
-def _build_covariate_config(raw: dict, *, task_name: str, task_path: str) -> TaskConfig:
-    covariate_target = raw["target_variable_name"]
-    covariate_names = list(raw.get("covariate_variable_names") or [])
-    if covariate_target in covariate_names:
+def build_task_config_from_raw(raw: dict[str, Any]) -> TaskConfig:
+    """Build a TaskConfig from a catalog task YAML document."""
+    if "target_variable_name" in raw:
         raise ValueError(
-            f"{task_name}: target_variable_name must not appear in covariate_variable_names"
+            f"Task {raw.get('task_name')!r}: singular 'target_variable_name' is not "
+            "allowed; use 'target_variable_names'."
         )
+    if "target_variable_names" not in raw:
+        raise ValueError(
+            f"Task {raw.get('task_name')!r}: missing required 'target_variable_names'."
+        )
+
+    task_name = raw["task_name"]
+    dataset_category = raw["dataset_category"]
+    dataset_name = raw["dataset_name"]
+    targets = list(raw["target_variable_names"])
+    covariates = list(raw.get("covariate_variable_names") or [])
+    task_mode = infer_task_mode(targets, covariates)
+    logical_path = f"{dataset_category}/{task_name}"
+
     return TaskConfig(
-        **_base_fields(
-            raw,
-            task_name=task_name,
-            task_path=task_path,
-            task_mode="covariate",
-        ),
-        target_variable_names=[covariate_target],
-        covariate_variable_names=covariate_names,
+        task_name=task_name,
+        task_path=logical_path,
+        task_description=raw.get("task_description") or "",
+        task_catalog=raw.get("task_catalog") or "application",
+        dataset_category=dataset_category,
+        dataset_name=dataset_name,
+        context_window=raw["context_window"],
+        forecast_horizon=raw["forecast_horizon"],
+        handle_missing=raw.get("handle_missing", "interpolate"),
+        normalization_method=raw.get("normalization_method", "standard"),
+        file_name=f"{dataset_name}.csv",
+        task_mode=task_mode,
+        target_variable_names=targets,
+        covariate_variable_names=covariates,
     )
 
 
 def build_task_config(task_dir: Path) -> TaskConfig:
-    """Build a TaskConfig from a task directory (folder basename = task_name)."""
-    task_dir = task_dir.resolve()
-    task_path = str(task_dir)
-    task_name = task_dir.name
-    raw = _read_task_documents(task_dir)[0]
-    kind = _task_kind(task_dir)
+    """
+    Legacy entry point kept for older call sites.
 
-    if kind == "univariate":
-        return _build_univariate_config(raw, task_name=task_name, task_path=task_path)
-    if kind == "multivariate":
-        return _build_multivariate_config(raw, task_name=task_name, task_path=task_path)
-    if kind == "covariate":
-        return _build_covariate_config(raw, task_name=task_name, task_path=task_path)
-    raise ValueError(f"Unsupported task folder kind {kind!r} under {task_dir}")
+    The new layout has no per-task directories. Prefer ``build_task_config_from_raw``.
+    """
+    raise RuntimeError(
+        "Per-folder task directories are no longer supported. "
+        f"Received {task_dir}. Use build_task_config_from_raw() with catalog YAML docs."
+    )
 
 
 def build_task_configs(logical_name: str, task_dir: Path) -> list[TaskConfig]:
-    """Backward-compatible wrapper returning a single TaskConfig."""
-    task_dir = task_dir.resolve()
-    if logical_name != task_dir.name:
-        raise ValueError(
-            f"Logical task name {logical_name!r} does not match folder {task_dir.name!r}"
-        )
+    """Backward-compatible wrapper; see ``build_task_config``."""
+    del logical_name
     return [build_task_config(task_dir)]
 
 
 def load_task_config_from_task_dir(task_dir: Path) -> TaskConfig:
-    """Load a single TaskConfig from a task directory."""
+    """Legacy loader; see ``build_task_config``."""
     return build_task_config(task_dir.resolve())

--- a/tests/helpers/task_config_fixtures.py
+++ b/tests/helpers/task_config_fixtures.py
@@ -1,4 +1,4 @@
-"""Shared helpers for constructing flat tasks TaskConfig objects in tests."""
+"""Shared helpers for constructing TaskConfig objects in tests."""
 
 from __future__ import annotations
 
@@ -9,7 +9,9 @@ def dummy_covariate_task_config(**overrides) -> TaskConfig:
     """Minimal covariate TaskConfig for preprocessor / tuner unit tests."""
     fields = {
         "task_name": "covariate_test",
-        "task_path": "/tmp/covariate/covariate_test",
+        "task_path": "commerce_and_trade/covariate_test",
+        "dataset_category": "commerce_and_trade",
+        "dataset_name": "covariate_test",
         "forecast_horizon": 1,
         "context_window": 1,
         "handle_missing": "interpolate",
@@ -27,7 +29,9 @@ def dummy_univariate_task_config(**overrides) -> TaskConfig:
     """Minimal univariate TaskConfig for preprocessor / tuner unit tests."""
     fields = {
         "task_name": "norm_test",
-        "task_path": "/tmp",
+        "task_path": "commerce_and_trade/norm_test",
+        "dataset_category": "commerce_and_trade",
+        "dataset_name": "norm_test",
         "forecast_horizon": 1,
         "context_window": 1,
         "handle_missing": "interpolate",

--- a/tests/unit/test_capability_multi_covariate.py
+++ b/tests/unit/test_capability_multi_covariate.py
@@ -1,0 +1,52 @@
+"""Unit tests for model capability gating with multi-target covariates."""
+
+import pytest
+
+from tempus_bench.utils.model_settings import (
+    ModelCapabilities,
+    assert_model_supports_task_family,
+    task_path_to_family,
+)
+
+
+def test_task_path_to_family_requires_mode():
+    with pytest.raises(ValueError, match="without task_mode"):
+        task_path_to_family("commerce_and_trade/Some Task")
+
+
+def test_task_path_to_family_uses_mode():
+    assert task_path_to_family("anything", task_mode="covariate") == "covariate"
+
+
+def test_multi_target_covariate_requires_multivariate():
+    cap = ModelCapabilities(
+        covariates="past_future",
+        univariate=True,
+        multivariate=False,
+    )
+    with pytest.raises(ValueError, match="multi-target covariate"):
+        assert_model_supports_task_family(
+            cap, model_name="demo", family="covariate", num_targets=2
+        )
+
+
+def test_single_target_covariate_ok_without_multivariate():
+    cap = ModelCapabilities(
+        covariates="past_future",
+        univariate=True,
+        multivariate=False,
+    )
+    assert_model_supports_task_family(
+        cap, model_name="demo", family="covariate", num_targets=1
+    )
+
+
+def test_multi_target_covariate_ok_with_multivariate():
+    cap = ModelCapabilities(
+        covariates="past_future",
+        univariate=True,
+        multivariate=True,
+    )
+    assert_model_supports_task_family(
+        cap, model_name="demo", family="covariate", num_targets=3
+    )

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -33,6 +33,31 @@ def _mock_task_manager(*, task_path: str = "*") -> Mock:
     return manager
 
 
+def _raw_task(**overrides):
+    base = {
+        "task_name": "test_task",
+        "task_description": "demo",
+        "task_catalog": "application",
+        "dataset_category": "commerce_and_trade",
+        "dataset_name": "test_task",
+        "context_window": 50,
+        "forecast_horizon": 24,
+        "handle_missing": "interpolate",
+        "normalization_method": "standard",
+        "target_variable_names": ["series_a"],
+        "covariate_variable_names": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_catalog_yaml(tasks_dir: Path, category: str, tasks: list[dict]) -> None:
+    catalog = tasks_dir / "Application Tasks"
+    catalog.mkdir(parents=True, exist_ok=True)
+    body = "\n---\n".join(yaml.dump({"task": t}, sort_keys=False) for t in tasks)
+    (catalog / f"{category}.yaml").write_text(body, encoding="utf-8")
+
+
 @pytest.fixture
 def sample_benchmark_config():
     """Sample benchmark configuration."""
@@ -116,25 +141,19 @@ class TestManagerGetAvailableModels:
     """Test suite for get_available_models utility function."""
 
     def test_get_available_models(self, tmp_path):
-        """Test getting available models from directory structure."""
+        """Test getting available models from flat models directory."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        # Create deterministic models
-        det_dir = models_dir / "deterministic"
-        det_dir.mkdir()
-
-        arima_dir = det_dir / "arima"
+        arima_dir = models_dir / "arima"
         arima_dir.mkdir()
         (arima_dir / "arima_model.py").write_text("# model file")
+        (arima_dir / "settings.yaml").write_text("python_version: '3.11'\n")
 
-        # Create stochastic models
-        stoch_dir = models_dir / "stochastic"
-        stoch_dir.mkdir()
-
-        deepar_dir = stoch_dir / "deepar"
+        deepar_dir = models_dir / "deepar"
         deepar_dir.mkdir()
         (deepar_dir / "deepar_model.py").write_text("# model file")
+        (deepar_dir / "settings.yaml").write_text("python_version: '3.11'\n")
 
         with patch("tempus_bench.utils.paths.get_models_dir", return_value=models_dir):
             available_models = get_available_models()
@@ -152,27 +171,21 @@ class TestManagerGetAvailableModels:
             assert available_models == set()
 
 
-# TestManagerValidateModelAvailability removed - _validate_model_availability method no longer exists
-
-
 class TestManagerConvertPydanticErrors:
-    """Test suite for _convert_pydantic_errors method."""
+    """Test suite for convert_pydantic_errors helper."""
 
     def test_convert_single_error(self):
-        """Test converting a single Pydantic error."""
-        from pydantic import ValidationError
+        from tempus_bench.utils.configs import convert_pydantic_errors
 
-        # Create a mock validation error
         error = Mock()
         error.errors = Mock(return_value=[{"loc": ("field",), "msg": "error message"}])
 
-        result = ConfigManager._convert_pydantic_errors(error)
+        result = convert_pydantic_errors(error)
         assert "field" in result
         assert "error message" in result
 
     def test_convert_multiple_errors(self):
-        """Test converting multiple Pydantic errors."""
-        from pydantic import ValidationError
+        from tempus_bench.utils.configs import convert_pydantic_errors
 
         error = Mock()
         error.errors = Mock(
@@ -182,7 +195,7 @@ class TestManagerConvertPydanticErrors:
             ]
         )
 
-        result = ConfigManager._convert_pydantic_errors(error)
+        result = convert_pydantic_errors(error)
         assert "field1" in result
         assert "field2" in result
         assert "error 1" in result
@@ -190,21 +203,19 @@ class TestManagerConvertPydanticErrors:
 
 
 class TestFindTaskDirectories:
-    """Test suite for find_task_directories function."""
+    """Test suite for find_task_directories / catalog discovery."""
 
     def test_find_all_task_directories(self, tmp_path):
-        """Test finding all task directories with '*' pattern."""
-        tasks_dir = tmp_path / "tasks"
-        tasks_dir.mkdir()
-
-        univariate_dir = tasks_dir / "univariate"
-        univariate_dir.mkdir()
-
-        task1_dir = univariate_dir / "task1"
-        task1_dir.mkdir()
-
-        task2_dir = univariate_dir / "task2"
-        task2_dir.mkdir()
+        """Test finding all tasks with '*' pattern."""
+        tasks_dir = tmp_path / "Tasks"
+        _write_catalog_yaml(
+            tasks_dir,
+            "commerce_and_trade",
+            [
+                _raw_task(task_name="task1", dataset_name="task1"),
+                _raw_task(task_name="task2", dataset_name="task2"),
+            ],
+        )
 
         with patch("tempus_bench.utils.paths.get_tasks_dir", return_value=tasks_dir):
             result = find_task_directories("*")
@@ -213,98 +224,109 @@ class TestFindTaskDirectories:
             assert "task2" in result
 
     def test_find_specific_subdirectory(self, tmp_path):
-        """Test finding task directories in specific subdirectory."""
-        tasks_dir = tmp_path / "tasks"
-        tasks_dir.mkdir()
-
-        univariate_dir = tasks_dir / "univariate"
-        univariate_dir.mkdir()
-
-        task1_dir = univariate_dir / "task1"
-        task1_dir.mkdir()
-
-        multivariate_dir = tasks_dir / "multivariate"
-        multivariate_dir.mkdir()
-
-        task2_dir = multivariate_dir / "task2"
-        task2_dir.mkdir()
+        """Test finding tasks in a specific dataset category."""
+        tasks_dir = tmp_path / "Tasks"
+        _write_catalog_yaml(
+            tasks_dir,
+            "commerce_and_trade",
+            [_raw_task(task_name="task1", dataset_name="task1")],
+        )
+        _write_catalog_yaml(
+            tasks_dir,
+            "manufacturing_and_industrial_production",
+            [
+                _raw_task(
+                    task_name="task2",
+                    dataset_category="manufacturing_and_industrial_production",
+                    dataset_name="task2",
+                )
+            ],
+        )
 
         with patch("tempus_bench.utils.paths.get_tasks_dir", return_value=tasks_dir):
-            result = find_task_directories("univariate/*")
+            result = find_task_directories("commerce_and_trade/*")
             assert len(result) == 1
             assert "task1" in result
 
     def test_find_specific_task_directory(self, tmp_path):
-        """Test finding a specific task directory."""
-        tasks_dir = tmp_path / "tasks"
-        tasks_dir.mkdir()
-
-        univariate_dir = tasks_dir / "univariate"
-        univariate_dir.mkdir()
-
-        task1_dir = univariate_dir / "specific_task"
-        task1_dir.mkdir()
+        """Test finding a specific task by category + human name."""
+        tasks_dir = tmp_path / "Tasks"
+        _write_catalog_yaml(
+            tasks_dir,
+            "commerce_and_trade",
+            [_raw_task(task_name="specific_task", dataset_name="specific_task")],
+        )
 
         with patch("tempus_bench.utils.paths.get_tasks_dir", return_value=tasks_dir):
-            result = find_task_directories("univariate/specific_task")
+            result = find_task_directories("commerce_and_trade/specific_task")
             assert len(result) == 1
             assert "specific_task" in result
 
     def test_find_nonexistent_subdirectory(self, tmp_path):
-        """Test finding task directories when subdirectory doesn't exist."""
-        tasks_dir = tmp_path / "tasks"
+        """Test finding tasks when category has no matches."""
+        tasks_dir = tmp_path / "Tasks"
         tasks_dir.mkdir()
+        (tasks_dir / "Application Tasks").mkdir()
 
         with patch("tempus_bench.utils.paths.get_tasks_dir", return_value=tasks_dir):
             result = find_task_directories("nonexistent/*")
             assert len(result) == 0
 
     def test_find_nonexistent_specific_task(self, tmp_path):
-        """Test finding task directories when specific task doesn't exist."""
-        tasks_dir = tmp_path / "tasks"
+        """Test finding a specific task that doesn't exist."""
+        tasks_dir = tmp_path / "Tasks"
         tasks_dir.mkdir()
+        (tasks_dir / "Application Tasks").mkdir()
 
         with patch("tempus_bench.utils.paths.get_tasks_dir", return_value=tasks_dir):
-            result = find_task_directories("univariate/nonexistent_task")
+            result = find_task_directories("commerce_and_trade/nonexistent_task")
             assert len(result) == 0
-
-
-# TestManagerValidateBenchmarkConfig removed - validate_benchmark_config method no longer exists
-
-
-# TestManagerValidateBenchmarkSettings removed - validate_benchmark_settings method no longer exists
 
 
 class TestManagerValidateModelSettings:
     """Test suite for validate_model_settings method."""
 
-    def test_validate_models_directory_not_found(self):
-        """Test that ValidationError is raised when models directory doesn't exist."""
+    def _manager(self, models=("arima",)):
         manager = Mock()
         manager.logger = Mock()
-        manager.models_evaluated = ["arima"]
-        manager.model_configs = {"arima": ModelConfig(model_name="arima")}
+        manager.models_evaluated = list(models)
+        manager.model_configs = {
+            name: ModelConfig(model_name=name) for name in models
+        }
+        manager._load_config = lambda path: ConfigManager._load_config(path)
+        return manager
+
+    def _caps_yaml(self) -> str:
+        return yaml.dump(
+            {
+                "python_version": "3.11",
+                "device": "cpu",
+                "capabilities": {
+                    "covariates": "none",
+                    "univariate": True,
+                    "multivariate": False,
+                },
+            }
+        )
+
+    def test_validate_models_directory_not_found(self):
+        """Missing settings for evaluated models raises ValidationError."""
+        manager = self._manager()
 
         with patch(
             "tempus_bench.utils.config_manager.get_models_dir",
             return_value=Path("nonexistent"),
         ):
-            with pytest.raises(ValidationError, match="Models directory not found"):
+            with pytest.raises(ValidationError, match="Missing or invalid settings"):
                 ConfigManager.init_model_setting(manager)
 
     def test_validate_model_settings_success(self, tmp_path):
         """Test successful validation of model settings."""
         models_dir = tmp_path / "models" / "arima"
         models_dir.mkdir(parents=True, exist_ok=True)
+        (models_dir / "settings.yaml").write_text(self._caps_yaml())
 
-        settings_file = models_dir / "settings.yaml"
-        settings_data = {"python_version": "3.11", "device": "cpu"}
-        settings_file.write_text(yaml.dump(settings_data))
-
-        manager = Mock()
-        manager.logger = Mock()
-        manager.models_evaluated = ["arima"]
-        manager.model_configs = {"arima": ModelConfig(model_name="arima")}
+        manager = self._manager()
 
         with patch(
             "tempus_bench.utils.config_manager.get_models_dir",
@@ -316,25 +338,18 @@ class TestManagerValidateModelSettings:
             assert result["arima"]["device"] == "cpu"
 
     def test_validate_model_settings_invalid_yaml(self, tmp_path):
-        """Test that invalid YAML raises ValidationError."""
+        """Test that invalid YAML raises ValueError."""
         models_dir = tmp_path / "models" / "arima"
         models_dir.mkdir(parents=True, exist_ok=True)
+        (models_dir / "settings.yaml").write_text("invalid: [yaml")
 
-        settings_file = models_dir / "settings.yaml"
-        settings_file.write_text("invalid: [yaml")
-
-        manager = Mock()
-        manager.logger = Mock()
-        manager.models_evaluated = ["arima"]
-        manager.model_configs = {"arima": ModelConfig(model_name="arima")}
+        manager = self._manager()
 
         with patch(
             "tempus_bench.utils.config_manager.get_models_dir",
             return_value=models_dir.parent,
         ):
-            with pytest.raises(
-                ValueError
-            ):  # _load_config raises ValueError for invalid YAML
+            with pytest.raises(ValueError):
                 ConfigManager.init_model_setting(manager)
 
     def test_validate_model_settings_filters_by_main_model(self, tmp_path):
@@ -342,151 +357,68 @@ class TestManagerValidateModelSettings:
         models_dir = tmp_path / "models"
         arima_dir = models_dir / "arima"
         arima_dir.mkdir(parents=True, exist_ok=True)
-        (arima_dir / "settings.yaml").write_text(
-            yaml.dump({"python_version": "3.11", "device": "cpu"})
-        )
+        (arima_dir / "settings.yaml").write_text(self._caps_yaml())
 
         prophet_dir = models_dir / "prophet"
         prophet_dir.mkdir()
-        (prophet_dir / "settings.yaml").write_text(
-            yaml.dump({"python_version": "3.11", "device": "cpu"})
-        )
+        (prophet_dir / "settings.yaml").write_text(self._caps_yaml())
 
-        manager = Mock()
-        manager.logger = Mock()
-        manager.models_evaluated = ["arima"]  # Only arima in main.model
-        manager.model_configs = {"arima": ModelConfig(model_name="arima")}
+        manager = self._manager(models=("arima",))
 
         with patch(
             "tempus_bench.utils.config_manager.get_models_dir", return_value=models_dir
         ):
             result = ConfigManager.init_model_setting(manager)
             assert "arima" in result
-            assert "prophet" not in result  # Should be filtered out
+            assert "prophet" not in result
 
 
 class TestManagerValidateTaskConfigs:
-    """Test suite for validate_task_configs method."""
+    """Test suite for init_tasks with catalog documents."""
 
-    def test_validate_task_config_not_found(self, tmp_path):
-        """Test that ValidationError is raised when task config doesn't exist."""
-        task_dir = tmp_path / "task1"
-        task_dir.mkdir()
-
+    def test_validate_task_configs_success(self):
+        """Test successful loading of task configs from documents."""
         manager = _mock_task_manager()
 
         with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"task1": str(task_dir)},
-        ):
-            with pytest.raises(FileNotFoundError, match="Missing task.yaml"):
-                ConfigManager.init_tasks(manager)
-
-    def test_validate_task_configs_success(self, tmp_path):
-        """Test successful validation of task configs."""
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-
-        task_file = task_dir / "task.yaml"
-        task_data = {
-            "task": {
-                "forecast_horizon": 24,
-                "context_window": 50,
-                "handle_missing": "interpolate",
-                "normalization_method": "standard",
-                "file_name": "test_dataset.csv",
-                "target_variable_names": ["series_a"],
-                "covariate_variable_names": [],
-            }
-        }
-        task_file.write_text(yaml.dump(task_data))
-
-        manager = _mock_task_manager()
-
-        with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
+            "tempus_bench.utils.task_assets.ensure_dataset_assets"
+        ), patch(
+            "tempus_bench.utils.paths.find_task_documents",
+            return_value={"test_task": _raw_task()},
         ):
             result = ConfigManager.init_tasks(manager)
             assert "test_task" in result
             assert result["test_task"].task_name == "test_task"
             assert result["test_task"].forecast_horizon == 24
+            assert result["test_task"].dataset_category == "commerce_and_trade"
 
-    def test_validate_task_configs_multi_doc_uses_first_document(self, tmp_path):
-        """Multi-document yaml uses the first valid task document only."""
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
+    def test_validate_task_configs_validation_error(self):
+        """Test that invalid task documents raise during build."""
+        manager = _mock_task_manager()
+        bad = _raw_task()
+        del bad["context_window"]
 
-        task_file = task_dir / "task.yaml"
-        task_file.write_text(
-            """task:
-  forecast_horizon: 24
-  context_window: 50
-  handle_missing: interpolate
-  normalization_method: standard
-  file_name: test_dataset.csv
-  target_variable_names: [series_a]
-  covariate_variable_names: []
----
-task:
-  forecast_horizon: 48
-  context_window: 100
-  handle_missing: drop
-  normalization_method: none
-  file_name: test_dataset.csv
-  target_variable_names: [series_a]
-  covariate_variable_names: []
-"""
-        )
+        with patch(
+            "tempus_bench.utils.task_assets.ensure_dataset_assets"
+        ), patch(
+            "tempus_bench.utils.paths.find_task_documents",
+            return_value={"test_task": bad},
+        ):
+            with pytest.raises((ValidationError, KeyError, TypeError, ValueError)):
+                ConfigManager.init_tasks(manager)
 
+    def test_validate_task_configs_empty_documents(self):
+        """Test that empty discovery result yields empty task map."""
         manager = _mock_task_manager()
 
         with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
+            "tempus_bench.utils.task_assets.ensure_dataset_assets"
+        ), patch(
+            "tempus_bench.utils.paths.find_task_documents",
+            return_value={},
         ):
             result = ConfigManager.init_tasks(manager)
-            assert result["test_task"].forecast_horizon == 24
-            assert result["test_task"].context_window == 50
-
-    def test_validate_task_configs_validation_error(self, tmp_path):
-        """Test that ValidationError is raised for invalid task config."""
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-
-        task_file = task_dir / "task.yaml"
-        task_file.write_text(
-            """task:
-  forecast_horizon: 24
-  # Missing context_window and required flat fields
-"""
-        )
-
-        manager = _mock_task_manager()
-
-        with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
-        ):
-            with pytest.raises((ValidationError, KeyError)):
-                ConfigManager.init_tasks(manager)
-
-    def test_validate_task_configs_empty_documents(self, tmp_path):
-        """Test that empty task config raises error."""
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-
-        task_file = task_dir / "task.yaml"
-        task_file.write_text("")
-
-        manager = _mock_task_manager()
-
-        with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
-        ):
-            with pytest.raises(ValueError, match="No valid task document"):
-                ConfigManager.init_tasks(manager)
+            assert result == {}
 
 
 class TestManagerFullIntegration:
@@ -495,28 +427,28 @@ class TestManagerFullIntegration:
     @patch("tempus_bench.utils.config_manager.LogManager")
     @patch("tempus_bench.utils.config_manager.get_project_root")
     @patch("tempus_bench.utils.config_manager.get_models_dir")
-    @patch("tempus_bench.utils.config_manager.get_tasks_dir")
+    @patch("tempus_bench.utils.paths.get_tasks_dir")
+    @patch("tempus_bench.utils.task_assets.ensure_dataset_assets")
     def test_config_manager_full_initialization(
         self,
+        mock_ensure_assets,
         mock_tasks_dir,
         mock_models_dir,
         mock_get_project_root,
         mock_logger,
         tmp_path,
     ):
-        """Test full ConfigManager initialization to cover __init__ lines 61-68."""
-        # Setup project root structure
+        """Test full ConfigManager initialization with Tasks/ catalog layout."""
         project_root = tmp_path
         tempus_bench_dir = project_root / "tempus_bench"
         tempus_bench_dir.mkdir()
         config_dir = tempus_bench_dir / "config"
         config_dir.mkdir()
 
-        # Setup benchmark config
         config_file = project_root / "benchmark.yaml"
         config_data = {
             "evaluation": {
-                "task_path": "univariate/*",
+                "task_path": "commerce_and_trade/*",
                 "tuning_loss": "mae",
                 "max_windows": 5,
                 "max_num_variates": 10,
@@ -525,144 +457,71 @@ class TestManagerFullIntegration:
         }
         config_file.write_text(yaml.dump(config_data))
 
-        # Setup settings in config directory
         settings_file = config_dir / "settings.yaml"
         settings_data = {
-            "logging_format": "%(message)s",
             "file_logging": True,
             "console_logging": True,
             "tensorboard_logging": True,
-            "runs_dir": "runs",
             "conda_env_prefix": "benchmark",
+            "reinstall_conda": False,
+            "verbose": False,
         }
         settings_file.write_text(yaml.dump(settings_data))
 
-        # Setup model settings
-        models_dir = tmp_path / "models" / "deterministic"
+        models_dir = tmp_path / "models"
         arima_dir = models_dir / "arima"
         arima_dir.mkdir(parents=True)
         (arima_dir / "settings.yaml").write_text(
-            yaml.dump({"python_version": "3.11", "device": "cpu"})
-        )
-        (arima_dir / "arima_model.py").write_text("# model file")
-
-        # Setup task
-        tasks_dir = tempus_bench_dir / "tasks" / "univariate"
-        task_dir = tasks_dir / "test_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text(
             yaml.dump(
                 {
-                    "task": {
-                        "forecast_horizon": 24,
-                        "context_window": 50,
-                        "handle_missing": "interpolate",
-                        "normalization_method": "standard",
-                        "file_name": "test.csv",
-                        "target_variable_names": ["series_a"],
-                        "covariate_variable_names": [],
-                    }
+                    "python_version": "3.11",
+                    "device": "cpu",
+                    "capabilities": {
+                        "covariates": "none",
+                        "univariate": True,
+                        "multivariate": False,
+                    },
                 }
             )
         )
+        (arima_dir / "arima_model.py").write_text("# model file")
+
+        tasks_dir = project_root / "Tasks"
+        _write_catalog_yaml(
+            tasks_dir,
+            "commerce_and_trade",
+            [_raw_task()],
+        )
 
         mock_get_project_root.return_value = project_root
-        mock_models_dir.return_value = models_dir.parent
-        mock_tasks_dir.return_value = tasks_dir.parent
+        mock_models_dir.return_value = models_dir
+        mock_tasks_dir.return_value = tasks_dir
         mock_logger.return_value = Mock()
 
-        # This will call __init__ and cover lines 61-68
         manager = ConfigManager(str(config_file))
         assert manager.config_path == str(config_file)
         assert isinstance(manager.model_configs, dict)
         assert isinstance(manager.evaluation_setting, EvaluationSetting)
-
-
-class TestManagerExceptionHandling:
-    """Test suite for exception handling paths."""
-
-    @patch("tempus_bench.utils.config_manager.get_logger")
-    def test_validate_config_validation_error_handling(self, mock_logger, tmp_path):
-        """Test ValidationError handling in config validation."""
-        config_file = tmp_path / "benchmark.yaml"
-        # Create invalid config that will trigger ValidationError
-        config_data = {
-            "evaluation": {
-                "task_path": "*",
-                "tuning_loss": "mae",
-                "max_windows": -1,
-            },  # Invalid
-            "model": {"arima": {"p": [1, 2]}},
-        }
-        config_file.write_text(yaml.dump(config_data))
-
-        class MockManager:
-            def __init__(self, config_path):
-                self.config_path = config_path
-                self.logger = Mock()
-
-            def _load_config(self, config_path):
-                return ConfigManager._load_config(config_path)
-
-            def _validate_model_availability(self, config):
-                # Mock implementation
-                pass
-
-            def _convert_pydantic_errors(self, error):
-                # Mock implementation
-                return "test error"
-
-        manager = MockManager(str(config_file))
-
-        # Note: validate_benchmark_config method no longer exists
-        # Configuration validation now happens during ConfigManager initialization
-        pass
-
-    @patch("tempus_bench.utils.config_manager.get_logger")
-    @patch("tempus_bench.utils.config_manager.get_models_dir")
-    def test_validate_model_settings_validation_error_handling(
-        self, mock_models_dir, mock_logger, tmp_path
-    ):
-        """Test ValidationError handling in validate_model_settings (lines 165-166)."""
-        models_dir = tmp_path / "models" / "deterministic" / "arima"
-        models_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create settings with invalid device
-        settings_file = models_dir / "settings.yaml"
-        settings_file.write_text("python_version: 3.11\ndevice: invalid")
-
-        manager = Mock()
-        manager.logger = Mock()
-        manager.models_evaluated = ["arima"]
-        manager.model_configs = {"arima": ModelConfig(model_name="arima")}
-
-        mock_models_dir.return_value = models_dir.parent
-
-        # This should not raise ValidationError since device validation is not done in init_model_setting
-        # Settings are just loaded as dictionaries
-        result = ConfigManager.init_model_setting(manager)
-        assert "arima" in result
-        assert result["arima"]["device"] == "invalid"
+        assert "test_task" in manager.task_configs
 
 
 class TestManagerTaskConfigBranch:
     """Test suite for task config validation branch."""
 
-    def test_task_config_without_task_key_raises_error(self, tmp_path):
-        """Test that task config without 'task' key raises error."""
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-
-        task_file = task_dir / "task.yaml"
-        task_file.write_text("forecast_horizon: 24")  # No 'task' key
-
+    def test_task_config_rejects_singular_target(self):
+        """Singular target_variable_name is rejected by the loader."""
         manager = _mock_task_manager()
+        bad = _raw_task()
+        bad["target_variable_name"] = "y"
+        del bad["target_variable_names"]
 
         with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
+            "tempus_bench.utils.task_assets.ensure_dataset_assets"
+        ), patch(
+            "tempus_bench.utils.paths.find_task_documents",
+            return_value={"test_task": bad},
         ):
-            with pytest.raises(ValueError, match="No valid task document"):
+            with pytest.raises(ValueError, match="target_variable_name"):
                 ConfigManager.init_tasks(manager)
 
 

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -126,18 +126,14 @@ class TestModelConfig:
         assert config.model_name == "arima"
 
     def test_model_config_missing_model_name(self):
-        """Test that missing model_name raises ValidationError."""
-        with pytest.raises(ValidationError):
+        """Test that missing model_name raises TypeError."""
+        with pytest.raises(TypeError):
             ModelConfig()  # type: ignore  # Missing required model_name
 
-    def test_model_config_extra_fields_forbidden(self):
-        """Test that extra fields are forbidden."""
-        with pytest.raises(ValidationError) as exc_info:
+    def test_model_config_extra_fields_must_be_lists(self):
+        """Test that non-list hyperparameter values raise ValueError."""
+        with pytest.raises(ValueError, match="must be a list"):
             ModelConfig(model_name="arima", extra_field="not allowed")  # type: ignore
-        assert (
-            "extra" in str(exc_info.value).lower()
-            or "forbidden" in str(exc_info.value).lower()
-        )
 
 
 class TestDatasetConfig:
@@ -172,7 +168,9 @@ class TestTaskConfig:
         """Test valid task configuration."""
         config = TaskConfig(
             task_name="test_task",
-            task_path="/path/to/task",
+            task_path="commerce_and_trade/test_task",
+            dataset_category="commerce_and_trade",
+            dataset_name="test_task",
             forecast_horizon=24,
             context_window=100,
             handle_missing="interpolate",
@@ -184,14 +182,16 @@ class TestTaskConfig:
         )
         assert config.forecast_horizon == 24
         assert config.context_window == 100
-        assert config.task_path == "/path/to/task"
+        assert config.task_path == "commerce_and_trade/test_task"
         assert config.dataset.file_name == "test.csv"
         assert config.is_normalize() is True
 
     def test_covariate_mode_helpers(self):
         config = TaskConfig(
             task_name="covariate_foo",
-            task_path="/path/to/covariate/covariate_foo",
+            task_path="commerce_and_trade/covariate_foo",
+            dataset_category="commerce_and_trade",
+            dataset_name="covariate_foo",
             forecast_horizon=8,
             context_window=32,
             handle_missing="interpolate",
@@ -209,7 +209,9 @@ class TestTaskConfig:
         with pytest.raises(ValidationError) as exc_info:
             TaskConfig(
                 task_name="test_task",
-                task_path="/path/to/task",
+                task_path="commerce_and_trade/test_task",
+                dataset_category="commerce_and_trade",
+                dataset_name="test_task",
                 forecast_horizon=200,
                 context_window=100,
                 handle_missing="interpolate",
@@ -225,7 +227,9 @@ class TestTaskConfig:
         with pytest.raises(ValidationError):
             TaskConfig(
                 task_name="test_task",
-                task_path="/path/to/task",
+                task_path="commerce_and_trade/test_task",
+                dataset_category="commerce_and_trade",
+                dataset_name="test_task",
                 forecast_horizon=0,
                 context_window=100,
                 handle_missing="interpolate",
@@ -240,7 +244,9 @@ class TestTaskConfig:
         with pytest.raises(ValidationError):
             TaskConfig(
                 task_name="test_task",
-                task_path="/path/to/task",
+                task_path="commerce_and_trade/test_task",
+                dataset_category="commerce_and_trade",
+                dataset_name="test_task",
                 forecast_horizon=24,
                 context_window=0,
                 handle_missing="interpolate",

--- a/tests/unit/test_dataset_assets_sync.py
+++ b/tests/unit/test_dataset_assets_sync.py
@@ -1,0 +1,74 @@
+"""Unit tests for Hugging Face Datasets/ sync helpers."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tempus_bench.utils import task_assets as assets
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    assets.reset_ensure_cache()
+    yield
+    assets.reset_ensure_cache()
+
+
+def test_ensure_fails_when_unreachable_and_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(assets, "_datasets_root", lambda: tmp_path / "Datasets")
+    monkeypatch.setattr(
+        assets,
+        "discover_expected_datasets",
+        lambda: [
+            assets.DatasetAssetSpec(
+                dataset_category="commerce_and_trade",
+                dataset_name="Demo",
+                local_path=tmp_path / "Datasets" / "commerce_and_trade" / "Demo" / "Demo.csv",
+                hf_path="Datasets/commerce_and_trade/Demo/Demo.csv",
+            )
+        ],
+    )
+    monkeypatch.delenv(assets.SKIP_DATASET_SYNC_ENV, raising=False)
+    monkeypatch.delenv(assets.SKIP_DOWNLOAD_ENV, raising=False)
+
+    with patch.object(
+        assets,
+        "_list_remote_dataset_csv_paths",
+        side_effect=RuntimeError("offline"),
+    ):
+        with pytest.raises(FileNotFoundError, match="unreachable"):
+            assets.ensure_dataset_assets(force=True)
+
+
+def test_ensure_downloads_missing(tmp_path: Path, monkeypatch):
+    root = tmp_path / "Datasets"
+    dest = root / "commerce_and_trade" / "Demo" / "Demo.csv"
+    monkeypatch.setattr(assets, "_datasets_root", lambda: root)
+    monkeypatch.setattr(
+        assets,
+        "discover_expected_datasets",
+        lambda: [
+            assets.DatasetAssetSpec(
+                dataset_category="commerce_and_trade",
+                dataset_name="Demo",
+                local_path=dest,
+                hf_path="Datasets/commerce_and_trade/Demo/Demo.csv",
+            )
+        ],
+    )
+    monkeypatch.delenv(assets.SKIP_DATASET_SYNC_ENV, raising=False)
+    monkeypatch.delenv(assets.SKIP_DOWNLOAD_ENV, raising=False)
+
+    def _fake_download(repo_id, revision, hf_path, dest_path: Path):
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text("variable_name,variable_unit,timestamps,values\n", encoding="utf-8")
+
+    with patch.object(
+        assets,
+        "_list_remote_dataset_csv_paths",
+        return_value={"Datasets/commerce_and_trade/Demo/Demo.csv"},
+    ), patch.object(assets, "_download_file", side_effect=_fake_download):
+        assets.ensure_dataset_assets(force=True)
+
+    assert dest.is_file()

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,246 +1,66 @@
-"""
-Unit tests for path utilities in tempus_bench.utils.paths.
+"""Unit tests for path utilities under the Tasks/ + Datasets/ layout."""
 
-This test verifies that all path functions generate correct absolute paths
-based on the project structure.
-"""
-
-import pytest
 from pathlib import Path
 
+import pytest
+
 from tempus_bench.utils.paths import (
-    get_project_root,
-    get_tasks_dir,
-    get_models_dir,
-    get_runs_dir,
+    find_task_directories,
+    find_task_documents,
+    get_dataset_path,
+    get_datasets_dir,
     get_logs_path,
-    get_task_path,
-    get_model_path,
+    get_models_dir,
+    get_project_root,
+    get_runs_dir,
+    get_tasks_dir,
     ensure_directory_exists,
 )
 
 
 class TestPathFunctions:
-    """Test suite for path utility functions."""
-    
     def test_get_project_root(self):
-        """Test that get_project_root returns the correct project root path."""
-        # The project root is the directory containing tempus_bench
-        # Since we're in tests/unit, go up 3 levels to reach project root
         expected_root = Path(__file__).parent.parent.parent
         actual_root = get_project_root()
-        
-        print(f"\nProject Root:")
-        print(f"  Expected: {expected_root}")
-        print(f"  Actual:   {actual_root}")
-        
-        assert actual_root == expected_root, f"Project root mismatch: expected {expected_root}, got {actual_root}"
-        assert actual_root.exists(), "Project root should exist"
-        
-        # Verify it contains tempus_bench directory
-        tempus_bench_dir = actual_root / "tempus_bench"
-        assert tempus_bench_dir.exists(), "Should contain tempus_bench directory"
-    
+        assert actual_root == expected_root
+        assert (actual_root / "tempus_bench").exists()
+
     def test_get_tasks_dir(self):
-        """Test that get_tasks_dir returns the correct tasks directory path."""
-        expected = get_project_root() / "tempus_bench" / "tasks"
-        actual = get_tasks_dir()
-        
-        print(f"\nTasks Directory:")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
-        
-        assert actual == expected, "Tasks directory path mismatch"
-    
+        assert get_tasks_dir() == get_project_root() / "Tasks"
+        assert get_tasks_dir().is_dir()
+
+    def test_get_datasets_dir_without_ensure(self):
+        assert get_datasets_dir(ensure=False) == get_project_root() / "Datasets"
+
     def test_get_models_dir(self):
-        """Test that get_models_dir returns the correct models directory path."""
-        expected = get_project_root() / "tempus_bench" / "models"
-        actual = get_models_dir()
-        
-        print(f"\nModels Directory:")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
-        
-        assert actual == expected, "Models directory path mismatch"
-    
+        assert get_models_dir() == get_project_root() / "tempus_bench" / "models"
+
     def test_get_runs_dir(self):
-        """Test that get_runs_dir returns the correct runs directory path."""
-        expected = get_project_root() / "runs"
-        actual = get_runs_dir()
-        
-        print(f"\nRuns Directory:")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
-        
-        assert actual == expected, "Runs directory path mismatch"
-    
+        assert get_runs_dir() == get_project_root() / "runs"
+
     def test_get_logs_path(self):
-        """Test that get_logs_path returns the correct logs directory path."""
-        expected = get_project_root() / "logs"
-        actual = get_logs_path()
-        
-        print(f"\nLogs Directory:")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
-        
-        assert actual == expected, "Logs directory path mismatch"
-    
-    def test_get_task_path(self):
-        """Test that get_task_path returns correct task-specific paths."""
-        task_name = "multivariate/multivariate_transport_monthly_airline_baggage_complaints"
-        expected = get_tasks_dir() / task_name
-        actual = get_task_path(task_name)
-        
-        print(f"\nTask Path:")
-        print(f"  Task: {task_name}")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
-        
-        assert actual == expected, "Task path mismatch"
-        
-        # Test with another task
-        task_name2 = "univariate/univariate_climate_daily_mean_humidity_delhi"
-        expected2 = get_tasks_dir() / task_name2
-        actual2 = get_task_path(task_name2)
-        
-        print(f"\nTask Path 2:")
-        print(f"  Task: {task_name2}")
-        print(f"  Expected: {expected2}")
-        print(f"  Actual:   {actual2}")
-        
-        assert actual2 == expected2, "Task path 2 mismatch"
-    
-    def test_get_model_path(self):
-        """Models live flat under ``tempus_bench/models/<name>`` (model_type is legacy)."""
-        model_type = "deterministic"
-        model_name = "arima"
-        expected = get_models_dir() / model_name
-        actual = get_model_path(model_type, model_name)
+        assert get_logs_path() == get_project_root() / "logs"
 
-        print(f"\nModel Path:")
-        print(f"  Type: {model_type}, Name: {model_name}")
-        print(f"  Expected: {expected}")
-        print(f"  Actual:   {actual}")
+    def test_get_dataset_path(self):
+        docs = find_task_documents("*")
+        doc = next(iter(docs.values()))
+        path = get_dataset_path(
+            doc["dataset_category"],
+            doc["dataset_name"],
+            ensure=False,
+        )
+        assert path.name == f"{doc['dataset_name']}.csv"
+        assert path.parent.name == doc["dataset_name"]
+        assert path.parent.parent.name == doc["dataset_category"]
 
-        assert actual == expected, "Model path mismatch"
+    def test_find_task_directories_compat(self):
+        mapping = find_task_directories("*")
+        assert mapping
+        name, selector = next(iter(mapping.items()))
+        assert "/" in selector
+        assert selector.endswith(name)
 
-        model_type2 = "stochastic"
-        model_name2 = "chronos_base"
-        expected2 = get_models_dir() / model_name2
-        actual2 = get_model_path(model_type2, model_name2)
-
-        print(f"\nModel Path 2:")
-        print(f"  Type: {model_type2}, Name: {model_name2}")
-        print(f"  Expected: {expected2}")
-        print(f"  Actual:   {actual2}")
-
-        assert actual2 == expected2, "Model path 2 mismatch"
-    
-    def test_path_consistency(self):
-        """Test that all base paths are consistent with each other."""
-        project_root = get_project_root()
-        
-        print(f"\nPath Consistency Check:")
-        print(f"  Project Root: {project_root}")
-        
-        # All should be under project_root
-        tasks = get_tasks_dir()
-        models = get_models_dir()
-        runs = get_runs_dir()
-        logs = get_logs_path()
-        
-        assert tasks.is_relative_to(project_root) or tasks == project_root
-        assert models.is_relative_to(project_root) or models == project_root
-        assert runs.is_relative_to(project_root) or runs == project_root
-        assert logs.is_relative_to(project_root) or logs == project_root
-        
-        print(f"  ✓ All paths are consistent with project root")
-    
-    def test_paths_are_absolute(self):
-        """Test that all returned paths are absolute paths."""
-        print(f"\nPath Absolute Check:")
-        
-        paths = [
-            ("project_root", get_project_root()),
-            ("tasks_dir", get_tasks_dir()),
-            ("models_dir", get_models_dir()),
-            ("runs_dir", get_runs_dir()),
-            ("logs_path", get_logs_path()),
-            ("task_path", get_task_path("univariate/univariate_climate_daily_mean_humidity_delhi")),
-            ("model_path", get_model_path("deterministic", "prophet")),
-        ]
-        
-        for name, path in paths:
-            print(f"  {name}: {path} (absolute: {path.is_absolute()})")
-            assert path.is_absolute(), f"{name} should be an absolute path"
-    
-    def test_ensure_directory_exists(self):
-        """Test that ensure_directory_exists creates directories properly."""
-        test_dir = get_runs_dir() / "test_temp_directory"
-        
-        print(f"\nEnsure Directory Exists:")
-        print(f"  Test directory: {test_dir}")
-        
-        # Ensure it doesn't exist first
-        if test_dir.exists():
-            test_dir.rmdir()
-        
-        # Test creation
-        ensure_directory_exists(test_dir)
-        assert test_dir.exists(), "Directory should be created"
-        assert test_dir.is_dir(), "Path should be a directory"
-        print(f"  ✓ Directory created successfully")
-        
-        # Test idempotency (should not raise error if exists)
-        ensure_directory_exists(test_dir)
-        assert test_dir.exists(), "Directory should still exist"
-        print(f"  ✓ Idempotent operation successful")
-        
-        # Cleanup
-        test_dir.rmdir()
-        print(f"  ✓ Cleanup successful")
-    
-    def test_all_paths_summary(self):
-        """Print a summary of all generated paths."""
-        print(f"\n" + "="*80)
-        print(f"SUMMARY OF ALL GENERATED PATHS")
-        print(f"="*80)
-        
-        print(f"\n1. Project Root:")
-        print(f"   {get_project_root()}")
-        
-        print(f"\n2. Tasks Directory:")
-        print(f"   {get_tasks_dir()}")
-        
-        print(f"\n3. Models Directory:")
-        print(f"   {get_models_dir()}")
-        
-        print(f"\n4. Runs Directory:")
-        print(f"   {get_runs_dir()}")
-        
-        print(f"\n5. Logs Directory:")
-        print(f"   {get_logs_path()}")
-        
-        print(f"\n6. Example Task Paths:")
-        examples = [
-            "multivariate/multivariate_transport_monthly_airline_baggage_complaints",
-            "univariate/univariate_climate_daily_mean_humidity_delhi",
-            "multivariate/multivariate_climate_hourly_madrid_air_pollution",
-        ]
-        for example in examples:
-            print(f"   Task '{example}': {get_task_path(example)}")
-        
-        print(f"\n7. Example Model Paths:")
-        model_examples = [
-            ("deterministic", "arima"),
-            ("deterministic", "prophet"),
-            ("stochastic", "chronos_base"),
-            ("stochastic", "chronos_tiny"),
-        ]
-        for model_type, model_name in model_examples:
-            print(f"   Model '{model_type}/{model_name}': {get_model_path(model_type, model_name)}")
-        
-        print(f"\n" + "="*80)
-        print(f"ALL PATHS VERIFIED")
-        print(f"="*80)
-
+    def test_ensure_directory_exists(self, tmp_path: Path):
+        target = tmp_path / "a" / "b"
+        ensure_directory_exists(target)
+        assert target.is_dir()

--- a/tests/unit/test_preprocessor_unknown_calendar.py
+++ b/tests/unit/test_preprocessor_unknown_calendar.py
@@ -5,10 +5,8 @@ import os
 os.environ.setdefault("TEMPUSBENCH_DISABLE_TENSORBOARD", "1")
 import sys
 import tempfile
-from pathlib import Path
 
 import pytest
-import yaml
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, PROJECT_ROOT)
@@ -37,17 +35,20 @@ def _log_manager():
 
 
 def test_clean_maps_unknown_start_and_freq():
-    task_yaml = (
-        Path(PROJECT_ROOT)
-        / "tempus_bench"
-        / "tasks"
-        / "univariate"
-        / "synthetic_nonstationary_univariate"
-        / "task.yaml"
+    tc = TaskConfig(
+        task_name="synthetic_nonstationary_univariate",
+        task_path="synthetic/synthetic_nonstationary_univariate",
+        dataset_category="synthetic",
+        dataset_name="synthetic_nonstationary_univariate",
+        forecast_horizon=24,
+        context_window=50,
+        handle_missing="interpolate",
+        normalization_method="standard",
+        file_name="synthetic_nonstationary_univariate.csv",
+        task_mode="univariate",
+        target_variable_names=["target"],
+        covariate_variable_names=[],
     )
-    doc = yaml.safe_load(task_yaml.read_text(encoding="utf-8"))
-    t = doc["task"]
-    tc = TaskConfig(**t, task_path=str(task_yaml.parent.resolve()))
     ev = EvaluationConfig(
         task_path="*",
         tuning_loss="mae",

--- a/tests/unit/test_task_assets.py
+++ b/tests/unit/test_task_assets.py
@@ -1,8 +1,7 @@
-"""Unit tests for tempus_bench.utils.task_assets."""
+"""Unit tests for tempus_bench.utils.task_assets (Datasets sync)."""
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,8 +10,10 @@ import pytest
 from tempus_bench.utils.paths import get_project_root
 from tempus_bench.utils.task_assets import (
     SKIP_DOWNLOAD_ENV,
-    discover_expected_assets,
-    ensure_task_assets,
+    SKIP_DATASET_SYNC_ENV,
+    DatasetAssetSpec,
+    discover_expected_datasets,
+    ensure_dataset_assets,
     reset_ensure_cache,
 )
 
@@ -24,157 +25,68 @@ def _reset_cache():
     reset_ensure_cache()
 
 
-def test_discover_expected_assets_finds_csvs():
-    tasks_root = get_project_root() / "tempus_bench" / "tasks"
+def test_discover_expected_datasets_from_tasks():
+    tasks_root = get_project_root() / "Tasks"
     if not tasks_root.is_dir():
-        pytest.skip("tasks directory not present locally")
+        pytest.skip("Tasks directory not present locally")
 
-    specs = discover_expected_assets(tasks_root)
-    assert len(specs) == 30
+    specs = discover_expected_datasets()
+    assert len(specs) >= 1
     assert all(spec.local_path.name.endswith(".csv") for spec in specs)
-    assert all(spec.hf_path.startswith("tasks/") for spec in specs)
+    assert all(spec.hf_path.startswith("Datasets/") for spec in specs)
 
 
-def test_ensure_task_assets_noop_when_complete():
-    tasks_root = get_project_root() / "tempus_bench" / "tasks"
-    if not tasks_root.is_dir():
-        pytest.skip("tasks directory not present locally")
+def test_ensure_dataset_assets_noop_when_complete():
+    tasks_root = get_project_root() / "Tasks"
+    datasets_root = get_project_root() / "Datasets"
+    if not tasks_root.is_dir() or not datasets_root.is_dir():
+        pytest.skip("Tasks/Datasets not present locally")
 
     missing = [
-        spec
-        for spec in discover_expected_assets(tasks_root)
-        if not spec.local_path.is_file()
+        spec for spec in discover_expected_datasets() if not spec.local_path.is_file()
     ]
     if missing:
-        pytest.skip("local task CSVs incomplete; skipping no-op test")
+        pytest.skip("local dataset CSVs incomplete; skipping no-op test")
 
     with patch("tempus_bench.utils.task_assets._download_file") as mock_dl:
-        ensure_task_assets()
+        ensure_dataset_assets()
         mock_dl.assert_not_called()
 
 
-def test_ensure_task_assets_raises_when_skip_and_incomplete(tmp_path, monkeypatch):
-    tasks_root = tmp_path / "tasks"
-    cat = tasks_root / "univariate" / "foo_univariate"
-    cat.mkdir(parents=True)
-    (cat / "task.yaml").write_text(
-        "task:\n  file_name: foo_univariate.csv\n  target_variable_names: [x]\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv(SKIP_DOWNLOAD_ENV, "1")
-
-    with patch(
-        "tempus_bench.utils.task_assets._tasks_root",
-        return_value=tasks_root,
-    ):
-        with pytest.raises(FileNotFoundError, match=SKIP_DOWNLOAD_ENV):
-            ensure_task_assets()
-
-
-def test_ensure_task_assets_downloads_missing_csv(tmp_path, monkeypatch):
-    tasks_root = tmp_path / "tasks"
-    task_dir = tasks_root / "univariate" / "foo_univariate"
-    task_dir.mkdir(parents=True)
-    (task_dir / "task.yaml").write_text(
-        "task:\n  file_name: foo_univariate.csv\n  target_variable_names: [x]\n",
-        encoding="utf-8",
-    )
-
-    downloaded: list[str] = []
-
-    def _fake_download(repo_id, hf_path, dest):
-        downloaded.append(hf_path)
-        dest.write_text("col\n", encoding="utf-8")
-
-    monkeypatch.delenv(SKIP_DOWNLOAD_ENV, raising=False)
-    with patch(
-        "tempus_bench.utils.task_assets._tasks_root",
-        return_value=tasks_root,
-    ):
-        with patch(
-            "tempus_bench.utils.task_assets._download_file",
-            side_effect=_fake_download,
-        ):
-            ensure_task_assets()
-
-    assert downloaded == ["tasks/univariate/foo_univariate/foo_univariate.csv"]
-    assert (task_dir / "foo_univariate.csv").is_file()
-
-
-def test_download_snapshot_uses_tempus_bench_package_root(tmp_path, monkeypatch):
-    project_root = tmp_path / "repo"
-    package_root = project_root / "tempus_bench"
-    tasks_root = package_root / "tasks"
-    package_root.mkdir(parents=True)
-
-    captured: dict[str, str] = {}
-
-    def _fake_snapshot_download(*, repo_id, repo_type, local_dir, allow_patterns):
-        captured["local_dir"] = local_dir
-        # Simulate HF layout: tasks/ under local_dir
-        target = Path(local_dir) / "tasks" / "univariate" / "foo"
-        target.mkdir(parents=True)
-        (target / "task.yaml").write_text("task:\n  file_name: foo.csv\n", encoding="utf-8")
-
+def test_ensure_raises_when_skip_and_incomplete(tmp_path, monkeypatch):
+    dest = tmp_path / "Datasets" / "commerce_and_trade" / "Demo" / "Demo.csv"
     monkeypatch.setattr(
-        "tempus_bench.utils.task_assets.get_project_root",
-        lambda: project_root,
+        "tempus_bench.utils.task_assets._datasets_root",
+        lambda: tmp_path / "Datasets",
     )
-    with patch(
-        "huggingface_hub.snapshot_download",
-        side_effect=_fake_snapshot_download,
-    ):
-        from tempus_bench.utils.task_assets import _download_snapshot
-
-        _download_snapshot("Smlcrm/tempus_bench_tasks", tasks_root)
-
-    assert captured["local_dir"] == str(package_root)
-    assert tasks_root.is_dir()
-
-
-def test_download_snapshot_relocates_misplaced_root_tasks(tmp_path, monkeypatch):
-    project_root = tmp_path / "repo"
-    package_root = project_root / "tempus_bench"
-    tasks_root = package_root / "tasks"
-    misplaced = project_root / "tasks"
-    misplaced.mkdir(parents=True)
-    (misplaced / "README.md").write_text("ok", encoding="utf-8")
-
-    def _fake_snapshot_download(*args, **kwargs):
-        pass  # no-op; only test relocation path
-
     monkeypatch.setattr(
-        "tempus_bench.utils.task_assets.get_project_root",
-        lambda: project_root,
+        "tempus_bench.utils.task_assets.discover_expected_datasets",
+        lambda: [
+            DatasetAssetSpec(
+                dataset_category="commerce_and_trade",
+                dataset_name="Demo",
+                local_path=dest,
+                hf_path="Datasets/commerce_and_trade/Demo/Demo.csv",
+            )
+        ],
     )
-    with patch(
-        "huggingface_hub.snapshot_download",
-        side_effect=_fake_snapshot_download,
-    ):
-        from tempus_bench.utils.task_assets import _download_snapshot
+    monkeypatch.setenv(SKIP_DATASET_SYNC_ENV, "1")
 
-        _download_snapshot("Smlcrm/tempus_bench_tasks", tasks_root)
-
-    assert tasks_root.is_dir()
-    assert not misplaced.exists()
-    assert (tasks_root / "README.md").is_file()
+    with pytest.raises(FileNotFoundError, match=SKIP_DATASET_SYNC_ENV):
+        ensure_dataset_assets(force=True)
 
 
-def test_get_tasks_dir_triggers_ensure(monkeypatch):
-    tasks_root = get_project_root() / "tempus_bench" / "tasks"
-    if not tasks_root.is_dir():
-        pytest.skip("tasks directory not present locally")
-
+def test_get_datasets_dir_triggers_ensure(monkeypatch):
     called = {"n": 0}
 
     def _fake_ensure():
         called["n"] += 1
 
     monkeypatch.setattr(
-        "tempus_bench.utils.task_assets.ensure_task_assets",
+        "tempus_bench.utils.task_assets.ensure_dataset_assets",
         _fake_ensure,
     )
     from tempus_bench.utils import paths
 
-    paths.get_tasks_dir()
+    paths.get_datasets_dir(ensure=True)
     assert called["n"] == 1

--- a/tests/unit/test_task_yaml_multi_doc.py
+++ b/tests/unit/test_task_yaml_multi_doc.py
@@ -1,85 +1,69 @@
-"""
-Unit tests for tasks task.yaml loading via shared task_yaml_loader.
-"""
+"""Unit tests for catalog task YAML loading via task_yaml_loader."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
-import yaml
 
 from tempus_bench.utils.configs import EvaluationConfig
 from tempus_bench.utils.config_manager import ConfigManager
 from tempus_bench.utils.task_yaml_loader import (
     build_task_config,
-    load_task_config_from_task_dir,
+    build_task_config_from_raw,
 )
 
-_FLAT_UNIVARIATE = """task:
-  context_window: 50
-  forecast_horizon: 24
-  handle_missing: interpolate
-  normalization_method: standard
-  file_name: test_dataset.csv
-  target_variable_names:
-  - series_a
-"""
+
+def _raw(**overrides):
+    base = {
+        "task_name": "test_task",
+        "task_description": "demo",
+        "task_catalog": "application",
+        "dataset_category": "commerce_and_trade",
+        "dataset_name": "test_task",
+        "context_window": 50,
+        "forecast_horizon": 24,
+        "handle_missing": "interpolate",
+        "normalization_method": "standard",
+        "target_variable_names": ["series_a"],
+        "covariate_variable_names": [],
+    }
+    base.update(overrides)
+    return base
 
 
 class TestTaskYamlLoader:
-    def test_load_flat_univariate_config(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text(_FLAT_UNIVARIATE, encoding="utf-8")
-
-        cfg = load_task_config_from_task_dir(task_dir)
+    def test_load_univariate_config(self):
+        cfg = build_task_config_from_raw(_raw())
         assert cfg.task_mode == "univariate"
         assert cfg.forecast_horizon == 24
         assert cfg.context_window == 50
         assert cfg.is_normalize() is True
         assert cfg.effective_targets() == ["series_a"]
+        assert cfg.file_name == "test_task.csv"
 
-    def test_covariate_folder_yaml(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "covariate" / "cov_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text(
-            yaml.dump(
-                {
-                    "task": {
-                        "context_window": 8,
-                        "forecast_horizon": 4,
-                        "handle_missing": "interpolate",
-                        "normalization_method": "none",
-                        "file_name": "cov.csv",
-                        "target_variable_name": "y",
-                        "covariate_variable_names": ["x1"],
-                    }
-                }
-            ),
-            encoding="utf-8",
+    def test_covariate_config(self):
+        cov = build_task_config_from_raw(
+            _raw(
+                target_variable_names=["y"],
+                covariate_variable_names=["x1"],
+                normalization_method="none",
+            )
         )
-
-        cov = build_task_config(task_dir)
         assert cov.task_mode == "covariate"
         assert cov.effective_targets() == ["y"]
         assert cov.effective_covariates() == ["x1"]
 
-    def test_config_manager_init_tasks_uses_shared_loader(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "univariate" / "test_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text(_FLAT_UNIVARIATE, encoding="utf-8")
-
-        from unittest.mock import Mock, patch
-
+    def test_config_manager_init_tasks_uses_documents(self):
         mgr = Mock()
         mgr.task_path = "*"
         mgr.evaluation_config = EvaluationConfig(task_path="*", max_windows=1)
         mgr.logger = Mock()
 
-        with patch(
-            "tempus_bench.utils.config_manager.find_task_directories",
-            return_value={"test_task": str(task_dir)},
+        with patch("tempus_bench.utils.task_assets.ensure_dataset_assets"), patch(
+            "tempus_bench.utils.paths.find_task_documents",
+            return_value={"test_task": _raw()},
         ):
             result = ConfigManager.init_tasks(mgr)
 
@@ -87,29 +71,6 @@ class TestTaskYamlLoader:
         assert result["test_task"].task_name == "test_task"
         assert result["test_task"].forecast_horizon == 24
 
-    def test_empty_file_raises(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "univariate" / "empty_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text("", encoding="utf-8")
-
-        with pytest.raises(ValueError, match="No valid task document"):
-            load_task_config_from_task_dir(task_dir)
-
-    def test_invalid_schema_raises(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "univariate" / "bad_task"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text(
-            "task:\n  forecast_horizon: 24\n",
-            encoding="utf-8",
-        )
-
-        with pytest.raises(Exception):
-            load_task_config_from_task_dir(task_dir)
-
-    def test_missing_task_key_raises(self, tmp_path: Path):
-        task_dir = tmp_path / "tasks" / "univariate" / "no_task_key"
-        task_dir.mkdir(parents=True)
-        (task_dir / "task.yaml").write_text("forecast_horizon: 24\n", encoding="utf-8")
-
-        with pytest.raises(ValueError, match="No valid task document"):
-            load_task_config_from_task_dir(task_dir)
+    def test_legacy_folder_loader_raises(self, tmp_path: Path):
+        with pytest.raises(RuntimeError, match="no longer supported"):
+            build_task_config(tmp_path / "old_task")

--- a/tests/unit/test_tasks_yaml_schema.py
+++ b/tests/unit/test_tasks_yaml_schema.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for tasks flat task.yaml schema, discovery, and loader validation.
-"""
+"""Unit tests for catalog task YAML schema, discovery, and loader."""
 
 from __future__ import annotations
 
@@ -9,182 +7,82 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tempus_bench.pipeline.data_loader import DataLoader
-from tempus_bench.utils.configs import EvaluationConfig
-from tempus_bench.utils.paths import find_task_directories, get_tasks_dir
+from tempus_bench.utils.paths import find_task_documents, get_tasks_dir
 from tempus_bench.utils.task_yaml_loader import (
-    build_task_config,
-    build_task_configs,
-    load_task_config_from_task_dir,
+    build_task_config_from_raw,
+    infer_task_mode,
 )
 
 
-def _write_univariate_task(task_dir: Path, *, file_name: str = "task.csv") -> None:
-    task_dir.mkdir(parents=True, exist_ok=True)
-    (task_dir / "task.yaml").write_text(
-        yaml.dump(
-            {
-                "task": {
-                    "context_window": 4,
-                    "forecast_horizon": 2,
-                    "handle_missing": "interpolate",
-                    "normalization_method": "standard",
-                    "file_name": file_name,
-                    "target_variable_names": ["series_a"],
-                }
-            }
-        ),
-        encoding="utf-8",
+def _raw_task(**overrides):
+    base = {
+        "task_name": "Demo Task",
+        "task_description": "demo",
+        "task_catalog": "application",
+        "dataset_category": "commerce_and_trade",
+        "dataset_name": "Demo_Task",
+        "context_window": 4,
+        "forecast_horizon": 2,
+        "handle_missing": "interpolate",
+        "normalization_method": "standard",
+        "target_variable_names": ["y"],
+        "covariate_variable_names": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_infer_task_mode_variants():
+    assert infer_task_mode(["y"], []) == "univariate"
+    assert infer_task_mode(["y1", "y2"], []) == "multivariate"
+    assert infer_task_mode(["y"], ["x"]) == "covariate"
+    assert infer_task_mode(["y1", "y2"], ["x"]) == "covariate"
+
+
+def test_build_rejects_singular_target_variable_name():
+    raw = _raw_task()
+    raw.pop("target_variable_names")
+    raw["target_variable_name"] = "y"
+    with pytest.raises(ValueError, match="target_variable_name"):
+        build_task_config_from_raw(raw)
+
+
+def test_build_task_config_from_raw_fields():
+    tc = build_task_config_from_raw(
+        _raw_task(covariate_variable_names=["x1", "x2"])
     )
+    assert tc.task_mode == "covariate"
+    assert tc.task_path == "commerce_and_trade/Demo Task"
+    assert tc.file_name == "Demo_Task.csv"
+    assert tc.dataset_category == "commerce_and_trade"
+    assert tc.dataset_name == "Demo_Task"
+    assert tc.task_catalog == "application"
 
 
-def _write_multivariate_task(task_dir: Path, *, file_name: str = "task.csv") -> None:
-    task_dir.mkdir(parents=True, exist_ok=True)
-    (task_dir / "task.yaml").write_text(
-        yaml.dump(
-            {
-                "task": {
-                    "context_window": 4,
-                    "forecast_horizon": 2,
-                    "handle_missing": "interpolate",
-                    "normalization_method": "none",
-                    "file_name": file_name,
-                    "target_variable_names": ["y", "x1", "x2"],
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+def test_catalog_tasks_dir_exists():
+    assert get_tasks_dir().name == "Tasks"
+    assert get_tasks_dir().is_dir()
 
 
-def _write_covariate_task(task_dir: Path, *, file_name: str = "task.csv") -> None:
-    task_dir.mkdir(parents=True, exist_ok=True)
-    (task_dir / "task.yaml").write_text(
-        yaml.dump(
-            {
-                "task": {
-                    "context_window": 4,
-                    "forecast_horizon": 2,
-                    "handle_missing": "interpolate",
-                    "normalization_method": "none",
-                    "file_name": file_name,
-                    "target_variable_name": "y",
-                    "covariate_variable_names": ["x1", "x2"],
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+def test_real_catalog_has_no_singular_target_field():
+    tasks_dir = get_tasks_dir()
+    offenders = []
+    for yaml_path in tasks_dir.rglob("*.yaml"):
+        for doc in yaml.safe_load_all(yaml_path.read_text(encoding="utf-8")):
+            if not doc or "task" not in doc:
+                continue
+            if "target_variable_name" in doc["task"]:
+                offenders.append(str(yaml_path))
+    assert offenders == []
 
 
-def _write_tasks_csv(task_dir: Path, file_name: str, rows: list[dict]) -> None:
-    import csv
-
-    path = task_dir / file_name
-    with path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(
-            handle,
-            fieldnames=[
-                "variable_name",
-                "variable_unit",
-                "timestamps",
-                "values",
-            ],
-        )
-        writer.writeheader()
-        writer.writerows(rows)
-
-
-class TestFlatTaskYamlSchema:
-    def test_univariate_config_fields(self, tmp_path: Path):
-        root = tmp_path / "tasks" / "univariate" / "foo_task"
-        _write_univariate_task(root)
-        cfg = load_task_config_from_task_dir(root)
-        assert cfg.task_mode == "univariate"
-        assert cfg.effective_targets() == ["series_a"]
-        assert cfg.effective_covariates() == []
-        assert cfg.is_normalize() is True
-        assert cfg.dataset.normalize is True
-        assert cfg.dataset.file_name == "task.csv"
-
-    def test_multivariate_and_covariate_folders(self, tmp_path: Path):
-        multi_root = tmp_path / "tasks" / "multivariate" / "bar_task"
-        cov_root = tmp_path / "tasks" / "covariate" / "bar_task_cov"
-        _write_multivariate_task(multi_root)
-        _write_covariate_task(cov_root)
-        joint = load_task_config_from_task_dir(multi_root)
-        cov = load_task_config_from_task_dir(cov_root)
-        assert joint.task_mode == "multivariate"
-        assert joint.effective_targets() == ["y", "x1", "x2"]
-        assert joint.effective_covariates() == []
-        assert cov.task_mode == "covariate"
-        assert cov.effective_targets() == ["y"]
-        assert cov.effective_covariates() == ["x1", "x2"]
-        assert cov.task_path != joint.task_path
-
-    def test_normalization_method_none(self, tmp_path: Path):
-        root = tmp_path / "tasks" / "univariate" / "no_norm"
-        _write_univariate_task(root, file_name="no_norm.csv")
-        yaml_path = root / "task.yaml"
-        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-        data["task"]["normalization_method"] = "none"
-        yaml_path.write_text(yaml.dump(data), encoding="utf-8")
-        cfg = load_task_config_from_task_dir(root)
-        assert cfg.is_normalize() is False
-        assert cfg.dataset.normalize is False
-
-    def test_find_task_directories_three_folders(self, tmp_path: Path, monkeypatch):
-        tasks_root = tmp_path / "tasks"
-        multi = tasks_root / "multivariate" / "mv_task"
-        cov = tasks_root / "covariate" / "cov_task"
-        _write_multivariate_task(multi)
-        _write_covariate_task(cov)
-        monkeypatch.setattr(
-            "tempus_bench.utils.paths.get_tasks_dir",
-            lambda: tasks_root,
-        )
-        all_tasks = find_task_directories("*")
-        assert set(all_tasks) == {"mv_task", "cov_task"}
-        only_cov = find_task_directories("covariate/cov_task")
-        assert list(only_cov) == ["cov_task"]
-
-    def test_loader_missing_variable_name_raises(self, tmp_path: Path):
-        root = tmp_path / "tasks" / "univariate" / "missing_row"
-        _write_univariate_task(root)
-        _write_tasks_csv(
-            root,
-            "task.csv",
-            [
-                {
-                    "variable_name": "other_name",
-                    "variable_unit": "unit",
-                    "timestamps": '["2020-01-01T00:00:00Z"]',
-                    "values": "[1.0]",
-                }
-            ],
-        )
-        cfg = load_task_config_from_task_dir(root)
-        eval_cfg = EvaluationConfig(task_path="*", max_windows=1)
-        with pytest.raises(ValueError, match="missing target variable_name"):
-            DataLoader(cfg, eval_cfg)
-
-
-class TestCatalogTasks2Yaml:
-    @pytest.mark.parametrize(
-        "task_name,path",
-        sorted(find_task_directories("*").items()),
-        ids=sorted(find_task_directories("*").keys()),
-    )
-    def test_catalog_task_yaml_builds(self, task_name: str, path: str):
-        configs = build_task_configs(task_name, Path(path))
-        assert len(configs) == 1
-        cfg = configs[0]
-        assert cfg.task_name == task_name
-        assert cfg.file_name
-        assert cfg.effective_targets()
-
-    def test_tasks_dir_points_at_tasks(self):
-        assert get_tasks_dir().name == "tasks"
-
-    def test_catalog_has_thirty_tasks(self):
-        assert len(find_task_directories("*")) == 30
+def test_find_task_documents_selectors():
+    all_tasks = find_task_documents("*")
+    assert len(all_tasks) >= 1
+    one = next(iter(all_tasks.values()))
+    category = one["dataset_category"]
+    name = one["task_name"]
+    exact = find_task_documents(f"{category}/{name}")
+    assert list(exact) == [name]
+    by_cat = find_task_documents(f"{category}/*")
+    assert name in by_cat


### PR DESCRIPTION
## Summary

Wires the TempusBench pipeline to the new catalog layout that already exists on `dev`: task definitions come from multi-doc YAML under `Tasks/`, and dataset CSVs sync from Hugging Face into repo-root `Datasets/`. Task discovery, `TaskConfig`, capability gating, and CSV resolution now use `dataset_category` / `dataset_name` and human task-name selectors instead of the old `tempus_bench/tasks/{univariate|multivariate|covariate}/…` folder layout. Model wrappers are unchanged.

## Files changed

**Core pipeline / utils**

| File | What changed |
|------|--------------|
| `.gitignore` | Ignore repo-root `Datasets/` (and HF staging dir) so synced CSVs are treated as a runtime cache, not source. |
| `tempus_bench/pipeline/data_loader.py` | Resolve the dataset CSV via `get_dataset_path(dataset_category, dataset_name)` instead of a task-folder-relative `file_name`. |
| `tempus_bench/pipeline/hyperparameter_tuner.py` | Use the new dataset-path resolution and key the results sink by `{task_mode}/{task_name}`. |
| `tempus_bench/utils/config_manager.py` | `init_tasks` now ensures dataset assets, discovers tasks via `find_task_documents`, builds configs with `build_task_config_from_raw`, and passes `num_targets` into capability checks. |
| `tempus_bench/utils/configs.py` | `TaskConfig` gains `dataset_category`, `dataset_name`, `task_catalog`, `task_description`; `task_path` becomes the logical `{category}/{task_name}` selector and `file_name` is derived. |
| `tempus_bench/utils/model_settings.py` | Capability family is taken from `task_mode`, and multi-target covariate tasks additionally require `capabilities.multivariate`. |
| `tempus_bench/utils/paths.py` | Point at repo-root `Tasks/` + `Datasets/` and add `find_task_documents`, `load_all_task_documents`, `get_datasets_dir`, `get_dataset_path`. |
| `tempus_bench/utils/task_assets.py` | Sync missing CSVs from HF `Smlcrm/tempus_bench_tasks` `Datasets/` (revision `dev`) once per process, failing if the Hub is unreachable and files are missing. |
| `tempus_bench/utils/task_yaml_loader.py` | Add `build_task_config_from_raw` + `infer_task_mode`; require `target_variable_names` and reject the old per-folder loaders. |

**Tests**

| File | What changed |
|------|--------------|
| `tests/helpers/task_config_fixtures.py` | Fixtures updated to build `TaskConfig` with the new `dataset_category` / `dataset_name` fields. |
| `tests/unit/test_config_manager.py` | Rewritten around document discovery and the new `init_tasks` flow. |
| `tests/unit/test_config_models.py` | `TaskConfig` / `ModelConfig` assertions updated for the new schema. |
| `tests/unit/test_paths.py` | Cover `Tasks/` + `Datasets/` discovery and dataset path resolution. |
| `tests/unit/test_preprocessor_unknown_calendar.py` | Build `TaskConfig` inline instead of reading an old per-folder task YAML. |
| `tests/unit/test_task_assets.py` | Cover the new `Datasets/` HF-sync inventory and download logic. |
| `tests/unit/test_task_yaml_multi_doc.py` | Cover multi-doc catalog YAML loading via `build_task_config_from_raw`. |
| `tests/unit/test_tasks_yaml_schema.py` | Enforce required `target_variable_names` and reject singular `target_variable_name`. |
| `tests/unit/test_capability_multi_covariate.py` *(new)* | Verify multi-target covariate tasks require both covariate and multivariate capability. |
| `tests/unit/test_dataset_assets_sync.py` *(new)* | Verify HF sync: missing+reachable downloads, missing+unreachable fails. |

## Detailed description of each change

**`.gitignore`** — Adds `Datasets/` (and the HF staging directory). Series CSVs are now a synced runtime cache pulled from Hugging Face, so they should not be tracked; task definitions remain in git under `Tasks/`.

**`tempus_bench/pipeline/data_loader.py`** — Previously each task folder colocated its CSV and the loader joined `task_path` with `file_name`. It now resolves the CSV through `get_dataset_path(dataset_category, dataset_name)`, i.e. `Datasets/{category}/{dataset_name}/{dataset_name}.csv`, decoupling data location from task-definition location.

**`tempus_bench/pipeline/hyperparameter_tuner.py`** — Uses the same category/name resolution for data and identifies the results sink by `{task_mode}/{task_name}` so outputs are grouped by inferred mode and human task name rather than the old family-folder path.

**`tempus_bench/utils/config_manager.py`** — `init_tasks` first calls `ensure_dataset_assets()` to sync CSVs, then discovers matching task documents with `find_task_documents(task_path | task_paths)` and builds each `TaskConfig` from the raw YAML doc. It also passes the target count into capability validation so multi-target covariate gating can be enforced.

**`tempus_bench/utils/configs.py`** — `TaskConfig` now stores catalog metadata (`task_catalog`, `task_description`) and the data-resolution keys (`dataset_category`, `dataset_name`). `task_path` is repurposed as the logical selector `{dataset_category}/{task_name}`, and `file_name` is derived as `{dataset_name}.csv` for backward-compatible call sites.

**`tempus_bench/utils/model_settings.py`** — Task family is now taken from the explicit `task_mode` instead of being parsed from a folder path. Covariate tasks still require `capabilities.covariates != none`, and covariate tasks with more than one target additionally require `capabilities.multivariate: true`.

**`tempus_bench/utils/paths.py`** — Repointed from `tempus_bench/tasks/{family}` to repo-root `Tasks/` and `Datasets/`. Adds `load_all_task_documents` (parse every catalog YAML, enforce unique task names, reject singular target key), `find_task_documents` (selector matching), `get_datasets_dir`, and `get_dataset_path`.

**`tempus_bench/utils/task_assets.py`** — Builds an expected-dataset inventory from the `Tasks/` YAMLs, compares it to local `Datasets/`, and downloads any missing CSVs from HF `Smlcrm/tempus_bench_tasks` at revision `dev` (overridable via env). Runs once per process; fails clearly if the Hub is unreachable while files are missing, and only warns about extra local datasets.

**`tempus_bench/utils/task_yaml_loader.py`** — Adds `build_task_config_from_raw` and `infer_task_mode` (mode derived from target/covariate lists). Requires `target_variable_names`, rejects the singular `target_variable_name`, and removes the old per-folder `task.yaml` loaders.

**Tests** — Fixtures and unit tests were migrated to the new schema and discovery APIs. Two new tests cover the added behaviors: multi-target covariate capability gating and the HF dataset-sync success/failure paths.

## What changed for running benchmarks

- **The CLI command did not change.** You still run `run_benchmark` / `python -m tempus_bench.run_benchmark --config <yaml>`.
- **Selector strings in the config changed.** Old family-path selectors (`univariate/foo`, `covariate/*`) are replaced by `{dataset_category}/{human task_name}` (and `{category}/*`, `*`).
- **Data is fetched from Hugging Face.** On first run, missing CSVs sync into `Datasets/` (revision `dev`). Old `univariate/…` style configs are no longer valid.

## New task structure and YAML

**Layout**

```
Tasks/
  Application Tasks/
    commerce_and_trade.yaml          # multi-doc: many `task:` entries
    energy_and_utilities.yaml
    ...
Datasets/
  commerce_and_trade/
    India_FMCG_Weekly_Sales/
      India_FMCG_Weekly_Sales.csv
      metadata.json
```

**Task YAML (one document per task, `---` separated)**

```yaml
task:
  task_name: India FMCG Weekly Sales        # unique, human-readable
  task_description: ...
  context_window: 52
  forecast_horizon: 8
  handle_missing: interpolate
  normalization_method: standard            # standard | none
  task_catalog: application
  dataset_category: commerce_and_trade      # folder under Datasets/
  dataset_name: India_FMCG_Weekly_Sales     # folder + CSV basename
  target_variable_names:                    # required list
  - sales value
  covariate_variable_names: []              # may be empty
```

Mode is **inferred** (not stored): 1 target + no covariates → `univariate`; N targets + no covariates → `multivariate`; any covariates → `covariate`.

**Dataset CSV columns:** `variable_name`, `variable_unit`, `timestamps` (JSON array of ISO-8601), `values` (JSON array of numbers), one row per variable.

**Selectors**

| Selector | Meaning |
|----------|---------|
| `*` | All tasks in every catalog under `Tasks/` |
| `commerce_and_trade/*` | All tasks in that category |
| `commerce_and_trade/India FMCG Weekly Sales` | One exact task |

## Commands to run benchmarks

```bash
# Default config
python -m tempus_bench.run_benchmark

# Explicit config
python -m tempus_bench.run_benchmark --config tempus_bench/config/benchmark.yaml

# New application-catalog smoke config
python -m tempus_bench.run_benchmark --config tempus_bench/config/application_tasks_smoke.yaml

# Console-script equivalent
run_benchmark --config tempus_bench/config/application_tasks_smoke.yaml
```

Example minimal config (univariate task, one model, single window):

```yaml
evaluation:
  task_paths:
    - commerce_and_trade/India FMCG Weekly Sales
  tuning_loss: mae
  max_windows: 1
  max_num_variates: 5
  num_samples: 5
  num_quantiles: 3
  point_forecast_statistic: mean
model:
  seasonal_naive:
    sp: [12]
```

