### PR TITLE
Add the generator taskbed: on-the-fly synthetic data with multi-seed evaluation

### DIFF
--- a/Tasks/Synthetic Tasks/Covariate.yaml
+++ b/Tasks/Synthetic Tasks/Covariate.yaml
@@ -1,0 +1,18 @@
+task:
+  task_name: Covariate Nonlinear
+  task_description: Covariate-driven target with a nonlinear, lagged link (returns
+    (T, 2) = [y, x]; x is the covariate, known over context+horizon per the TempusBench
+    task definition)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: covariate
+  dataset_name: covariate_nonlinear
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names:
+  - x

--- a/Tasks/Synthetic Tasks/Intermittency.yaml
+++ b/Tasks/Synthetic Tasks/Intermittency.yaml
@@ -1,0 +1,48 @@
+task:
+  task_name: Intermittent Bursty
+  task_description: Intermittent demand with serially dependent occurrence
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: intermittency
+  dataset_name: intermittent_bursty
+  target_type: count_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Lumpy Demand
+  task_description: 'Lumpy demand (Syntetos-Boylan ''lumpy'' quadrant): rare occurrences
+    AND highly variable sizes'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: intermittency
+  dataset_name: lumpy_demand
+  target_type: count_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Zero Inflated Continuous
+  task_description: Zero-inflated *continuous* series (precipitation analogue)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: intermittency
+  dataset_name: zero_inflated_continuous
+  target_type: continuous_zero_inflated
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Memory.yaml
+++ b/Tasks/Synthetic Tasks/Memory.yaml
@@ -1,0 +1,47 @@
+task:
+  task_name: MA(1)
+  task_description: 'Invertible MA(1): y_t = eps_t + theta*eps_{t-1}, eps ~ N(0, sigma^2).'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: memory
+  dataset_name: ma1
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: AR(2) Pseudocyclic
+  task_description: Stationary AR(2) with complex roots (stochastic pseudo-cycles)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: memory
+  dataset_name: ar2_pseudocyclic
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Long Memory fGn
+  task_description: Fractional Gaussian noise with Hurst H=0.9 (long memory).
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: memory
+  dataset_name: long_memory_fgn
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Multivariate.yaml
+++ b/Tasks/Synthetic Tasks/Multivariate.yaml
@@ -1,0 +1,90 @@
+task:
+  task_name: MV Correlated Noise
+  task_description: m AR(1) series with strongly correlated innovations (returns (T,
+    m))
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: multivariate
+  dataset_name: mv_correlated_noise
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y1
+  - y2
+  - y3
+  covariate_variable_names: []
+---
+task:
+  task_name: MV VAR
+  task_description: Bivariate VAR(1) with genuine cross-dynamics (returns (T, 2))
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: multivariate
+  dataset_name: mv_var
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y1
+  - y2
+  covariate_variable_names: []
+---
+task:
+  task_name: MV Leadlag
+  task_description: 'Leading indicator: x leads y by lag steps (returns (T, 2) = [y,
+    x])'
+  context_window: 512
+  forecast_horizon: 16
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: multivariate
+  dataset_name: mv_leadlag
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y1
+  - y2
+  covariate_variable_names: []
+---
+task:
+  task_name: MV Common Factor
+  task_description: 'Factor structure: m=4 series driven by one latent AR(1) factor
+    (returns (T, 4))'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: multivariate
+  dataset_name: mv_common_factor
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y1
+  - y2
+  - y3
+  - y4
+  covariate_variable_names: []
+---
+task:
+  task_name: MV Cointegrated
+  task_description: Cointegrated pair sharing one stochastic trend (returns (T, 2))
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: multivariate
+  dataset_name: mv_cointegrated
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y1
+  - y2
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Noise.yaml
+++ b/Tasks/Synthetic Tasks/Noise.yaml
@@ -1,0 +1,144 @@
+task:
+  task_name: IID Gaussian
+  task_description: 'White noise: y_t ~ iid N(mu, sigma^2).'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: iid_gaussian
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Heteroskedastic Level
+  task_description: Level-dependent (multiplicative-style) heteroskedasticity
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: heteroskedastic_level
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Heteroskedastic Time
+  task_description: 'Time-driven variance growth: y_t = 10 sin(2 pi t/24) + sigma(t)*eps_t,
+    with sigma(t) = sigma0 + (sigma1-sigma0)*(t/T) rising 0.5 -> 2.5.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: heteroskedastic_time
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: GARCH Noise
+  task_description: GARCH(1,1) with zero conditional mean (volatility clustering)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: garch_noise
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Heavy Tailed Noise
+  task_description: Student-t(3) innovations on the reference sinusoid
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: heavy_tailed_noise
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Skewed Noise
+  task_description: Right-skewed innovations (centred, unit-variance log-normal)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: skewed_noise
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Autocorrelated Noise
+  task_description: AR(1) errors around a deterministic sinusoid
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: autocorrelated_noise
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Outlier Contaminated
+  task_description: Additive-outlier contamination of the reference sinusoid
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: outlier_contaminated
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Measurement Error RW
+  task_description: Local-level state-space model (signal + measurement error)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: noise
+  dataset_name: measurement_error_rw
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Nonlinearity.yaml
+++ b/Tasks/Synthetic Tasks/Nonlinearity.yaml
@@ -1,0 +1,49 @@
+task:
+  task_name: SETAR
+  task_description: Self-exciting threshold AR with asymmetric persistence (threshold
+    0)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: nonlinearity
+  dataset_name: setar
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Logistic Map
+  task_description: 'Chaotic logistic map: x_{t+1} = r x_t (1 - x_t), r=3.9, x in
+    (0,1).'
+  context_window: 512
+  forecast_horizon: 20
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: nonlinearity
+  dataset_name: logistic_map
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Mackey Glass
+  task_description: Mackey-Glass delay differential equation (chaotic regime, tau=17)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: nonlinearity
+  dataset_name: mackey_glass
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Seasonality.yaml
+++ b/Tasks/Synthetic Tasks/Seasonality.yaml
@@ -1,0 +1,160 @@
+task:
+  task_name: Noise Free Composite
+  task_description: 'Deterministic, noise-free signal: trend + two incommensurate
+    sines.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: noise_free_composite
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Low SNR Seasonal
+  task_description: 'Weak sinusoid buried in noise: y_t = amp*sin(2 pi t/24) + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: low_snr_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Sinusoidal Seasonal
+  task_description: 'Pure stationary cycle: y_t = amp*sin(2 pi t/period) + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: sinusoidal_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Multi Seasonal
+  task_description: Two nested periods (daily-in-weekly analogue)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: multi_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Nonsinusoidal Seasonal
+  task_description: Sharp, asymmetric periodic shape (exponentiated-sine "spike train")
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: nonsinusoidal_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Trend Seasonal Additive
+  task_description: Non-stationary cyclical, additive composition
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: trend_seasonal_additive
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Trend Seasonal Multiplicative
+  task_description: Non-stationary cyclical, multiplicative composition
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: trend_seasonal_multiplicative
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Damped Seasonal
+  task_description: Regressive (decaying-amplitude) cycle
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: damped_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Irregular Period Seasonal
+  task_description: Frequency-modulated cycle with smoothly drifting period.
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: irregular_period_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Evolving Seasonal
+  task_description: Slowly morphing seasonal shape via drifting Fourier coefficients.
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: seasonality
+  dataset_name: evolving_seasonal
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Stationarity.yaml
+++ b/Tasks/Synthetic Tasks/Stationarity.yaml
@@ -1,0 +1,31 @@
+task:
+  task_name: Mean Reverting AR(1)
+  task_description: 'Stationary AR(1), phi=0.8: strongly mean-reverting level.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: stationarity
+  dataset_name: mean_reverting_ar1
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Near Unit Root AR(1)
+  task_description: 'AR(1) with phi=0.995: stationary but nearly integrated.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: stationarity
+  dataset_name: near_unit_root_ar1
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Structural Change.yaml
+++ b/Tasks/Synthetic Tasks/Structural Change.yaml
@@ -1,0 +1,49 @@
+task:
+  task_name: Level Shift
+  task_description: One-off mean shift on the reference sinusoid
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: structural_change
+  dataset_name: level_shift
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Variance Shift
+  task_description: 'One-off variance break: sigma jumps 1.0 -> 2.5 at 0.6T on the
+    reference sinusoid (conditional mean unchanged).'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: structural_change
+  dataset_name: variance_shift
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Markov Switching AR
+  task_description: 'Recurring regimes: 2-state Markov chain (stay prob 0.97, mean
+    sojourn ~33 steps) switching the mean and dynamics of an AR(1)'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: structural_change
+  dataset_name: markov_switching_ar
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Target Type.yaml
+++ b/Tasks/Synthetic Tasks/Target Type.yaml
@@ -1,0 +1,113 @@
+task:
+  task_name: Binary Latent AR
+  task_description: Binary series from a thresholded latent process
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: binary_latent_ar
+  target_type: binary
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Ordinal Categorical
+  task_description: 'Ordered 3-category series: the same latent construction as binary_latent_ar,
+    cut at thresholds (-0.8, +0.8)'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: ordinal_categorical
+  target_type: categorical_ordinal
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Poisson Counts
+  task_description: Non-negative counts, canonical log-link Poisson
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: poisson_counts
+  target_type: count_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: NegBin Counts
+  task_description: Overdispersed counts via a Gamma-Poisson (negative binomial) mixture
+    with the same mean path as poisson_counts
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: negbin_counts
+  target_type: count_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Skellam Integer
+  task_description: Signed integers (difference of two seasonal Poisson flows)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: skellam_integer
+  target_type: count_signed
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Lognormal Positive
+  task_description: Strictly positive continuous series, multiplicative on every scale
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: lognormal_positive
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Intermittent Demand
+  task_description: Zero-inflated intermittent demand (Croston setting)
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: target_type
+  dataset_name: intermittent_demand
+  target_type: count_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/Tasks/Synthetic Tasks/Trend.yaml
+++ b/Tasks/Synthetic Tasks/Trend.yaml
@@ -1,0 +1,129 @@
+task:
+  task_name: Random Walk
+  task_description: 'Driftless random walk: y_t = y_{t-1} + sigma*eps_t, y_0 = 0.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: random_walk
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Random Walk Drift
+  task_description: 'Random walk with drift: y_t = drift + y_{t-1} + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: random_walk_drift
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Linear Trend
+  task_description: 'Trend-stationary linear trend: y_t = a + b*(t/T) + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: linear_trend
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Exponential Trend
+  task_description: 'Exponential growth: y_t = y0 * growth^(t/T) + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: exponential_trend
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Log Trend
+  task_description: 'Logarithmic (decelerating) trend: y_t = base + c*ln(1+t) + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: log_trend
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Power Trend
+  task_description: 'Power-law ("p-root") trend: y_t = base + scale*(t/T)^p + sigma*eps_t.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: power_trend
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Logistic Trend
+  task_description: 'Sigmoid (saturating) trend: y_t = base + L/(1 + exp(-k(t - t0)))
+    + sigma*eps_t'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: none
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: logistic_trend
+  target_type: continuous_positive
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []
+---
+task:
+  task_name: Piecewise Linear Trend
+  task_description: 'Broken trend: slope b1/T before the break at frac_break*T, b2/T
+    after (continuous at the break), plus N(0, sigma^2) noise.'
+  context_window: 512
+  forecast_horizon: 64
+  handle_missing: interpolate
+  normalization_method: standard
+  task_catalog: synthetic
+  dataset_category: trend
+  dataset_name: piecewise_linear_trend
+  target_type: continuous_real
+  series_length: 2048
+  target_variable_names:
+  - y
+  covariate_variable_names: []

--- a/scripts/build_synthetic_task_yamls.py
+++ b/scripts/build_synthetic_task_yamls.py
@@ -1,0 +1,121 @@
+"""Regenerate Tasks/Synthetic Tasks/*.yaml from tempus_bench/generators/metadata.json.
+
+One file per category, and each generator appears exactly once, in its primary
+category. The catalog loader requires task_name to be unique across all of
+Tasks/, so a generator cannot be repeated under every category it is tagged
+with; the full tag list stays in metadata.json for per-category reporting.
+
+Re-run after any metadata change; never hand-edit the output.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tempus_bench import generators  # noqa: E402
+from tempus_bench.utils.paths import get_project_root  # noqa: E402
+
+OUT = Path(get_project_root()) / "Tasks" / "Synthetic Tasks"
+
+CATEGORY_TITLES = {
+    "stationarity": "Stationarity",
+    "trend": "Trend",
+    "seasonality": "Seasonality",
+    "noise": "Noise",
+    "memory": "Memory",
+    "nonlinearity": "Nonlinearity",
+    "structural_change": "Structural Change",
+    "target_type": "Target Type",
+    "intermittency": "Intermittency",
+    "multivariate": "Multivariate",
+    "covariate": "Covariate",
+}
+
+
+# Registry keys are snake_case; naive .title() mangles the statistical acronyms.
+ACRONYMS = {
+    "ar": "AR",
+    "ar1": "AR(1)",
+    "ar2": "AR(2)",
+    "ma1": "MA(1)",
+    "mv": "MV",
+    "garch": "GARCH",
+    "setar": "SETAR",
+    "iid": "IID",
+    "fgn": "fGn",
+    "snr": "SNR",
+    "negbin": "NegBin",
+    "var": "VAR",
+    "rw": "RW",
+}
+
+
+def _title(name: str) -> str:
+    """Human-readable task name for a registry key."""
+    return " ".join(ACRONYMS.get(word, word.capitalize()) for word in name.split("_"))
+
+
+def _variables(name: str, entry: dict) -> tuple[list[str], list[str]]:
+    """Target and covariate names, matching the generator's column order."""
+    if entry["variate"] == "covariate":
+        return ["y"], ["x"]
+    if entry["variate"] == "multivariate":
+        # The column count is a property of the generator, so ask it rather than
+        # duplicating each generator's default width in the metadata.
+        width = generators.generate(name, T=8, seed=0).shape[1]
+        return [f"y{i + 1}" for i in range(width)], []
+    return ["y"], []
+
+
+def _document(name: str, entry: dict, category: str) -> dict:
+    targets, covariates = _variables(name, entry)
+    return {
+        "task": {
+            "task_name": _title(name),
+            "task_description": entry["description"],
+            "context_window": entry["context_window"],
+            "forecast_horizon": entry["forecast_horizon"],
+            "handle_missing": "interpolate",
+            "normalization_method": entry["normalization_method"],
+            "task_catalog": "synthetic",
+            "dataset_category": category,
+            "dataset_name": name,
+            "target_type": entry["target_type"],
+            "series_length": entry["default_series_length"],
+            "target_variable_names": targets,
+            "covariate_variable_names": covariates,
+        }
+    }
+
+
+def main() -> None:
+    metadata = generators.load_metadata()
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    by_category: dict[str, list[dict]] = {}
+    for name, entry in metadata.items():
+        for category in entry["categories"]:
+            if category not in CATEGORY_TITLES:
+                raise SystemExit(
+                    f"{name}: unknown category {category!r}; add it to CATEGORY_TITLES"
+                )
+        category = entry["primary_category"]
+        by_category.setdefault(category, []).append(_document(name, entry, category))
+
+    total = 0
+    for category, documents in sorted(by_category.items()):
+        path = OUT / f"{CATEGORY_TITLES[category]}.yaml"
+        with path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump_all(documents, handle, sort_keys=False, allow_unicode=True)
+        total += len(documents)
+        print(f"{path.name}: {len(documents)} task(s)")
+    print(f"{total} documents over {len(metadata)} generators")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/split_generators.py
+++ b/scripts/split_generators.py
@@ -1,0 +1,158 @@
+"""Record of the one-time split of eval-synthetic-dataset/synthetic_generators.py
+into tempus_bench/generators/.
+
+Wrote one module per generator, a shared _common.py, and metadata.json (the
+registry). Kept for auditability of that migration; it is not imported at run
+time and cannot be re-run, because its input file was removed once the split was
+verified to reproduce every generator's output exactly.
+
+metadata.json is now the source of truth. To change a generator's metadata, edit
+that file and re-run scripts/build_synthetic_task_yamls.py. Generator ids in it
+are permanent: renumbering changes every derived seed.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "eval-synthetic-dataset" / "synthetic_generators.py"
+OUT = ROOT / "tempus_bench" / "generators"
+
+SHARED_FUNCS = {"_rng", "_t", "_ar1", "_base_signal"}
+SHARED_CONSTS = {"DEFAULT_T", "PERIOD", "LONG_PERIOD", "BURN_IN"}
+
+# Section 5 of synthetic_tasks.md: per-task window exceptions.
+WINDOW_OVERRIDES = {
+    "multi_seasonal": {"context_window": 512},
+    "mv_leadlag": {"forecast_horizon": 16},
+    "logistic_map": {"forecast_horizon": 20},
+}
+
+
+def _summarise(docstring: str) -> str:
+    """One-line description from a generator docstring.
+
+    Takes the first paragraph only (the rest is the DGP derivation), collapses it
+    onto one line, strips RST inline literals, and drops a trailing colon left by
+    a lead-in to a formula block.
+    """
+    block = docstring.strip().split("\n\n")[0]
+    text = " ".join(line.strip() for line in block.splitlines())
+    text = text.replace("``", "")
+    text = re.sub(r"\s+", " ", text).strip().rstrip(":")
+    if len(text) > 200:
+        text = text[:200].rsplit(" ", 1)[0] + "..."
+    return text
+
+
+def main() -> None:
+    source = SRC.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+
+    def segment(node: ast.AST) -> str:
+        """Exact source text of a top-level node."""
+        return "".join(lines[node.lineno - 1 : node.end_lineno])
+
+    funcs: dict[str, ast.FunctionDef] = {}
+    consts: dict[str, ast.Assign] = {}
+    tasks_node: ast.Assign | None = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            funcs[node.name] = node
+        elif isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+            if name == "TASKS":
+                tasks_node = node
+            else:
+                consts[name] = node
+
+    if tasks_node is None:
+        raise SystemExit("TASKS registry not found in the source file")
+
+    # Each value is a dict(fn=<name>, variate=..., ...) call, so it is not a
+    # literal and ast.literal_eval cannot read it. Walk the keywords instead:
+    # `fn` is a bare Name referring to the generator function, the rest are
+    # literals.
+    registry: dict[str, dict] = {}
+    for key_node, value_node in zip(tasks_node.value.keys, tasks_node.value.values):
+        name = ast.literal_eval(key_node)
+        spec: dict = {}
+        for keyword in value_node.keywords:
+            if keyword.arg == "fn":
+                spec["function"] = keyword.value.id
+            else:
+                spec[keyword.arg] = ast.literal_eval(keyword.value)
+        registry[name] = spec
+
+    OUT.mkdir(parents=True, exist_ok=True)
+
+    # --- _common.py ---------------------------------------------------------
+    common = [
+        '"""Shared constants and helpers for the data generators.\n\n',
+        "Extracted verbatim from the original synthetic_generators.py so the\n",
+        "per-generator modules stay byte-identical in behaviour.\n",
+        '"""\n\n',
+        "from __future__ import annotations\n\nimport numpy as np\n\n",
+    ]
+    for name in sorted(SHARED_CONSTS):
+        common.append(segment(consts[name]))
+    for name in sorted(SHARED_FUNCS):
+        common.append("\n\n" + segment(funcs[name]).rstrip() + "\n")
+    (OUT / "_common.py").write_text("".join(common), encoding="utf-8")
+
+    # --- one module per generator -------------------------------------------
+    metadata: dict[str, dict] = {}
+    for gen_id, (name, spec) in enumerate(registry.items(), start=1):
+        fn_name = spec["function"]
+        body = segment(funcs[fn_name]).rstrip() + "\n"
+        used = sorted(
+            symbol
+            for symbol in SHARED_FUNCS | SHARED_CONSTS
+            if re.search(rf"\b{symbol}\b", body)
+        )
+        header = [
+            f'"""Generator: {name}.\n\n',
+            "See eval-synthetic-dataset/synthetic_tasks.md for the design rationale\n",
+            "and the full data-generating process.\n",
+            '"""\n\n',
+            "from __future__ import annotations\n\nimport numpy as np\n",
+        ]
+        if used:
+            header.append(f"\nfrom ._common import {', '.join(used)}\n")
+        (OUT / f"{name}.py").write_text("".join(header) + "\n\n" + body, encoding="utf-8")
+
+        docstring = ast.get_docstring(funcs[fn_name]) or ""
+        summary = _summarise(docstring)
+        entry = {
+            "generator_id": gen_id,
+            "function": fn_name,
+            "primary_category": spec["categories"][0],
+            "categories": spec["categories"],
+            "variate": spec["variate"],
+            "target_type": spec["target_type"],
+            "description": summary,
+            "default_series_length": 2048,
+            "context_window": 512,
+            "forecast_horizon": 64,
+            # Normalising a count, binary or strictly positive target would
+            # destroy the property the task exists to test.
+            "normalization_method": (
+                "standard" if spec["target_type"] == "continuous_real" else "none"
+            ),
+        }
+        entry.update(WINDOW_OVERRIDES.get(name, {}))
+        metadata[name] = entry
+
+    (OUT / "metadata.json").write_text(
+        json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(metadata)} generator modules + metadata.json to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tempus_bench/config/benchmark.yaml
+++ b/tempus_bench/config/benchmark.yaml
@@ -3,6 +3,10 @@
 
 evaluation:
   task_path: 'covariate/covariate_transport_monthly_airline_baggage_complaints'
+  # Base seed(s) for generator tasks. One int, or a list to evaluate every seed
+  # and select hyperparameters on the averaged tuning loss. Application tasks
+  # ignore this. Each extra seed multiplies run time.
+  seeds: [0, 1, 2]
   tuning_loss: mae
   max_windows: 4
   max_num_variates: 10

--- a/tempus_bench/generators/__init__.py
+++ b/tempus_bench/generators/__init__.py
@@ -1,0 +1,101 @@
+"""Data generators for the TempusBench generator taskbed.
+
+One module per generator; ``metadata.json`` is the registry and doubles as the
+generator-to-category mapping. Generator modules are imported lazily so a run
+only pays for the generators it actually uses.
+
+Typical use::
+
+    from tempus_bench import generators
+
+    seed = generators.resolve_seed(base_seed=0, name="random_walk")
+    series = generators.generate("random_walk", T=2048, seed=seed)
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_METADATA_PATH = Path(__file__).parent / "metadata.json"
+
+SEED_STRIDE = 10_000
+"""Multiplier applied to the base seed before adding the generator ID.
+
+Keeps per-generator seed ranges disjoint across base seeds, so no two
+(base seed, generator) pairs ever resolve to the same effective seed. A plain
+additive offset would collide: base 5 with ID 3 and base 6 with ID 2 both give 8.
+
+Changing this value changes every derived seed and invalidates published results.
+"""
+
+
+@functools.lru_cache(maxsize=1)
+def load_metadata() -> dict[str, dict[str, Any]]:
+    """Return the generator registry, keyed by generator name."""
+    with _METADATA_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _entry(name: str) -> dict[str, Any]:
+    metadata = load_metadata()
+    if name not in metadata:
+        raise KeyError(f"Unknown generator {name!r}; not present in metadata.json")
+    return metadata[name]
+
+
+def _resolve_callable(name: str):
+    """Import the module for one generator and return its function."""
+    entry = _entry(name)
+    module = importlib.import_module(f"{__name__}.{name}")
+    return getattr(module, entry["function"])
+
+
+def resolve_seed(base_seed: int, name: str) -> int:
+    """Effective seed for one generator under a given base seed.
+
+    Args:
+        base_seed: The base seed from ``benchmark.yaml``.
+        name: Generator name, a key of ``metadata.json``.
+
+    Returns:
+        ``base_seed * SEED_STRIDE + generator_id``.
+
+    Raises:
+        KeyError: If the generator is not in the registry.
+    """
+    return base_seed * SEED_STRIDE + _entry(name)["generator_id"]
+
+
+def generate(
+    name: str,
+    T: int | None = None,
+    seed: int | None = None,
+    **kwargs: Any,
+) -> np.ndarray:
+    """Generate the series for one generator.
+
+    Args:
+        name: Generator name, a key of ``metadata.json``.
+        T: Series length. Defaults to the generator's ``default_series_length``.
+        seed: Effective seed; pass the value returned by :func:`resolve_seed`.
+        **kwargs: Forwarded to the generator function.
+
+    Returns:
+        ``(T,)`` for univariate generators, ``(T, m)`` otherwise.
+
+    Raises:
+        KeyError: If the generator is not in the registry.
+    """
+    entry = _entry(name)
+    if T is None:
+        T = entry["default_series_length"]
+    return _resolve_callable(name)(T=T, seed=seed, **kwargs)
+
+
+__all__ = ["SEED_STRIDE", "generate", "load_metadata", "resolve_seed"]

--- a/tempus_bench/generators/_common.py
+++ b/tempus_bench/generators/_common.py
@@ -1,0 +1,42 @@
+"""Shared constants and helpers for the data generators.
+
+Extracted verbatim from the original synthetic_generators.py so the
+per-generator modules stay byte-identical in behaviour.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+BURN_IN = 512             # burn-in steps for recursive processes
+DEFAULT_T = 2048          # default series length
+LONG_PERIOD = 168         # long seasonal period ("weekly" analogue)
+PERIOD = 24               # base seasonal period ("daily" analogue)
+
+
+def _ar1(rng, T, phi, sigma, mu=0.0):
+    """Stationary AR(1): x_t = mu + phi*(x_{t-1}-mu) + sigma*eps_t.
+
+    Initialised from the stationary distribution N(mu, sigma^2/(1-phi^2)),
+    so no burn-in is needed.  Requires |phi| < 1.
+    """
+    x = np.empty(T)
+    x[0] = mu + rng.standard_normal() * sigma / np.sqrt(1.0 - phi**2)
+    eps = rng.standard_normal(T) * sigma
+    for t in range(1, T):
+        x[t] = mu + phi * (x[t - 1] - mu) + eps[t]
+    return x
+
+
+def _base_signal(T):
+    """Common carrier signal for the noise-category tasks."""
+    return 10.0 * np.sin(2 * np.pi * _t(T) / PERIOD)
+
+
+def _rng(seed):
+    return np.random.default_rng(seed)
+
+
+def _t(T):
+    """Time index 0, 1, ..., T-1 as float."""
+    return np.arange(T, dtype=float)

--- a/tempus_bench/generators/ar2_pseudocyclic.py
+++ b/tempus_bench/generators/ar2_pseudocyclic.py
@@ -1,0 +1,31 @@
+"""Generator: ar2_pseudocyclic.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def ar2_pseudocyclic(T=DEFAULT_T, seed=None, phi1=1.5, phi2=-0.9, sigma=1.0):
+    """Stationary AR(2) with complex roots (stochastic pseudo-cycles):
+
+        y_t = phi1*y_{t-1} + phi2*y_{t-2} + sigma*eps_t.
+
+    Spectral peak near period 2 pi / arccos(phi1/(2 sqrt(-phi2))) ~= 9.5,
+    but the phase diffuses: unlike true seasonality the cycle cannot be
+    extrapolated far ahead.  Distinguishes models that infer dynamics from
+    those that pattern-match a fixed calendar period.  Burn-in removes the
+    zero-initialisation transient.
+    """
+    rng = _rng(seed)
+    n = T + BURN_IN
+    y = np.zeros(n)
+    eps = rng.standard_normal(n) * sigma
+    for t in range(2, n):
+        y[t] = phi1 * y[t - 1] + phi2 * y[t - 2] + eps[t]
+    return y[BURN_IN:]

--- a/tempus_bench/generators/autocorrelated_noise.py
+++ b/tempus_bench/generators/autocorrelated_noise.py
@@ -1,0 +1,25 @@
+"""Generator: autocorrelated_noise.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _base_signal, _rng
+
+
+def autocorrelated_noise(T=DEFAULT_T, seed=None, phi=0.8, sigma=0.6):
+    """AR(1) errors around a deterministic sinusoid:
+
+        y_t = 10 sin(2 pi t/24) + u_t,   u_t = phi*u_{t-1} + sigma*eps_t.
+
+    The optimal forecast corrects the sinusoid by phi^h times the last
+    residual - a model that treats residuals as white noise leaves
+    first-lag structure on the table.  (Classic regression-with-ARMA-errors
+    setting.)
+    """
+    rng = _rng(seed)
+    return _base_signal(T) + _ar1(rng, T, phi, sigma)

--- a/tempus_bench/generators/binary_latent_ar.py
+++ b/tempus_bench/generators/binary_latent_ar.py
@@ -1,0 +1,29 @@
+"""Generator: binary_latent_ar.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _ar1, _rng, _t
+
+
+def binary_latent_ar(T=DEFAULT_T, seed=None, phi=0.9, sigma=0.4, amp=1.5):
+    """Binary series from a thresholded latent process:
+
+        z_t = phi*z_{t-1} + sigma*eps_t + amp*sin(2 pi t/24) applied as
+        z_t = AR(1)(phi, sigma) + amp*sin(2 pi t/24),
+        y_t = 1{z_t > 0}  in {0, 1}.
+
+    Persistence and seasonality make P(y_{t+h}=1 | context) genuinely
+    dynamic (roughly 0.1-0.9 over a cycle); the Bayes probability is the
+    Gaussian CDF of the predicted latent mean over its predictive sd.
+    Tests forecasting on a two-point support where regression-style outputs
+    must be interpretable as probabilities/thresholded states.
+    """
+    rng = _rng(seed)
+    z = _ar1(rng, T, phi, sigma) + amp * np.sin(2 * np.pi * _t(T) / PERIOD)
+    return (z > 0.0).astype(float)

--- a/tempus_bench/generators/covariate_nonlinear.py
+++ b/tempus_bench/generators/covariate_nonlinear.py
@@ -1,0 +1,33 @@
+"""Generator: covariate_nonlinear.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _ar1, _rng
+
+
+def covariate_nonlinear(T=DEFAULT_T, seed=None, lag=2, sigma_y=0.3):
+    """Covariate-driven target with a nonlinear, lagged link (returns
+    (T, 2) = [y, x]; x is the covariate, known over context+horizon per the
+    TempusBench task definition):
+
+        x_t = 5 sin(2 pi t/24) + AR(1)(0.8, 1.0),
+        y_t = 4 tanh(x_{t-lag} / 3) + sigma_y * nu_t.
+
+    Given the covariate path, y is almost deterministic - but only through
+    a saturating nonlinearity and a 2-step lag.  Linear covariate handling
+    leaves large errors at |x| extremes; ignoring the covariate leaves the
+    task nearly unpredictable at long horizons.
+    """
+    rng = _rng(seed)
+    t_full = np.arange(-lag, T, dtype=float)
+    x_full = 5.0 * np.sin(2 * np.pi * t_full / PERIOD) \
+        + _ar1(rng, T + lag, 0.8, 1.0)
+    x = x_full[lag:]
+    y = 4.0 * np.tanh(x_full[:T] / 3.0) + sigma_y * rng.standard_normal(T)
+    return np.column_stack([y, x])

--- a/tempus_bench/generators/damped_seasonal.py
+++ b/tempus_bench/generators/damped_seasonal.py
@@ -1,0 +1,26 @@
+"""Generator: damped_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def damped_seasonal(T=DEFAULT_T, seed=None, amp0=12.0, sigma=1.0):
+    """Regressive (decaying-amplitude) cycle:
+
+        y_t = amp0 * exp(-t/tau) * sin(2 pi t/24) + sigma*eps_t,  tau = T/2.
+
+    Amplitude decays 12 -> 12*e^-2 ~= 1.6 across the series.  The model
+    must extrapolate the *envelope*, not the last-seen amplitude: repeating
+    the final context cycle overshoots the horizon amplitude.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    return amp0 * np.exp(-t / (T / 2.0)) * np.sin(2 * np.pi * t / PERIOD) \
+        + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/evolving_seasonal.py
+++ b/tempus_bench/generators/evolving_seasonal.py
@@ -1,0 +1,35 @@
+"""Generator: evolving_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _ar1, _rng, _t
+
+
+def evolving_seasonal(T=DEFAULT_T, seed=None, sigma=1.0):
+    """Slowly morphing seasonal shape via drifting Fourier coefficients.
+
+        y_t = sum_{k=1..3} [a_k(t) cos(k w t) + b_k(t) sin(k w t)] + sigma*eps_t
+
+    with w = 2 pi/24.  Each coefficient follows a highly persistent AR(1)
+    (phi = 0.997, innovation sd 0.15) around base values a = (0,0,0),
+    b = (6,3,1.5) - mean-reverting, so amplitudes stay bounded (unlike a
+    random-walk drift, which would wander arbitrarily).  The seasonal shape
+    a model should use is the *recent* one, not the context-wide average.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    w = 2 * np.pi / PERIOD
+    base_a = np.array([0.0, 0.0, 0.0])
+    base_b = np.array([6.0, 3.0, 1.5])
+    y = sigma * rng.standard_normal(T)
+    for k in range(3):
+        a = _ar1(rng, T, 0.997, 0.15, mu=base_a[k])
+        b = _ar1(rng, T, 0.997, 0.15, mu=base_b[k])
+        y += a * np.cos((k + 1) * w * t) + b * np.sin((k + 1) * w * t)
+    return y

--- a/tempus_bench/generators/exponential_trend.py
+++ b/tempus_bench/generators/exponential_trend.py
@@ -1,0 +1,22 @@
+"""Generator: exponential_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def exponential_trend(T=DEFAULT_T, seed=None, y0=3.0, growth=10.0, sigma=0.8):
+    """Exponential growth: y_t = y0 * growth^(t/T) + sigma*eps_t.
+
+    Level rises 3 -> 30.  Tests out-of-range level extrapolation with
+    accelerating increments; linear extrapolation of the context under-
+    shoots the horizon.
+    """
+    rng = _rng(seed)
+    return y0 * np.power(growth, _t(T) / T) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/garch_noise.py
+++ b/tempus_bench/generators/garch_noise.py
@@ -1,0 +1,35 @@
+"""Generator: garch_noise.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def garch_noise(T=DEFAULT_T, seed=None, omega=0.05, alpha=0.1, beta=0.85):
+    """GARCH(1,1) with zero conditional mean (volatility clustering):
+
+        y_t = sigma_t * eps_t,   sigma_t^2 = omega + alpha*y_{t-1}^2
+                                             + beta*sigma_{t-1}^2.
+
+    alpha+beta = 0.95 < 1 (covariance-stationary, unconditional variance
+    omega/(1-alpha-beta) = 1); initialised at the unconditional variance
+    with a burn-in.  The Bayes point forecast is 0 - the task is purely
+    probabilistic: predictive spread must expand and contract with the
+    volatility state.  Excess kurtosis is the visible fingerprint.
+    """
+    rng = _rng(seed)
+    n = T + BURN_IN
+    y = np.empty(n)
+    var = omega / (1.0 - alpha - beta)
+    eps = rng.standard_normal(n)
+    y[0] = np.sqrt(var) * eps[0]
+    for t in range(1, n):
+        var = omega + alpha * y[t - 1] ** 2 + beta * var
+        y[t] = np.sqrt(var) * eps[t]
+    return y[BURN_IN:]

--- a/tempus_bench/generators/heavy_tailed_noise.py
+++ b/tempus_bench/generators/heavy_tailed_noise.py
@@ -1,0 +1,26 @@
+"""Generator: heavy_tailed_noise.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng
+
+
+def heavy_tailed_noise(T=DEFAULT_T, seed=None, df=3.0, scale=1.0):
+    """Student-t(3) innovations on the reference sinusoid:
+
+        y_t = 10 sin(2 pi t/24) + scale * t_df / sqrt(df/(df-2)).
+
+    Innovations are standardised to unit variance but have infinite fourth
+    moment: rare shocks are ~an order of magnitude larger than Gaussian
+    ones.  Tests robustness of context encoding and realistic tail width in
+    predictive distributions.
+    """
+    rng = _rng(seed)
+    innov = rng.standard_t(df, size=T) / np.sqrt(df / (df - 2.0))
+    return _base_signal(T) + scale * innov

--- a/tempus_bench/generators/heteroskedastic_level.py
+++ b/tempus_bench/generators/heteroskedastic_level.py
@@ -1,0 +1,29 @@
+"""Generator: heteroskedastic_level.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def heteroskedastic_level(T=DEFAULT_T, seed=None, rel=0.08):
+    """Level-dependent (multiplicative-style) heteroskedasticity:
+
+        level_t = 12 + 6 sin(2 pi t / 1024)   (slow, NON-monotonic),
+        y_t = level_t + 3 sin(2 pi t/24) + rel*level_t*eps_t.
+
+    Noise sd is proportional to the level.  The level is deliberately
+    non-monotonic so that sigma ~ level is distinguishable from sigma ~ t
+    (with a monotone level the two are confounded).  Probabilistic metrics
+    (CRPS/WIS) reward models whose predictive spread tracks the level.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    level = 12.0 + 6.0 * np.sin(2 * np.pi * t / 1024.0)
+    return level + 3.0 * np.sin(2 * np.pi * t / PERIOD) \
+        + rel * level * rng.standard_normal(T)

--- a/tempus_bench/generators/heteroskedastic_time.py
+++ b/tempus_bench/generators/heteroskedastic_time.py
@@ -1,0 +1,24 @@
+"""Generator: heteroskedastic_time.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng, _t
+
+
+def heteroskedastic_time(T=DEFAULT_T, seed=None, sigma0=0.5, sigma1=2.5):
+    """Time-driven variance growth: y_t = 10 sin(2 pi t/24) + sigma(t)*eps_t,
+    with sigma(t) = sigma0 + (sigma1-sigma0)*(t/T) rising 0.5 -> 2.5.
+
+    Conditional-mean structure is unchanged from the reference sinusoid;
+    only the noise level trends.  Point metrics should degrade gracefully
+    and predictive intervals should widen with t.
+    """
+    rng = _rng(seed)
+    sig = sigma0 + (sigma1 - sigma0) * (_t(T) / T)
+    return _base_signal(T) + sig * rng.standard_normal(T)

--- a/tempus_bench/generators/iid_gaussian.py
+++ b/tempus_bench/generators/iid_gaussian.py
@@ -1,0 +1,23 @@
+"""Generator: iid_gaussian.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def iid_gaussian(T=DEFAULT_T, seed=None, mu=0.0, sigma=1.0):
+    """White noise: y_t ~ iid N(mu, sigma^2).
+
+    Control task: there is no exploitable structure.  The Bayes point
+    forecast is the constant mu and the Bayes MSE is sigma^2 at every
+    horizon.  A model that "finds" structure (forecast variance across
+    windows well above 0) is hallucinating.
+    """
+    rng = _rng(seed)
+    return mu + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/intermittent_bursty.py
+++ b/tempus_bench/generators/intermittent_bursty.py
@@ -1,0 +1,33 @@
+"""Generator: intermittent_bursty.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def intermittent_bursty(T=DEFAULT_T, seed=None, phi=0.95, thresh=0.84):
+    """Intermittent demand with serially dependent occurrence:
+
+        z_t = 0.95 z_{t-1} + sqrt(1-0.95^2) eps_t   (latent, stationary sd 1),
+        o_t = 1{z_t > 0.84}   (marginal occurrence prob ~0.2, in runs),
+        y_t = o_t * (1 + Poisson(2)).
+
+    The persistent latent makes demand arrive in bursts separated by long
+    quiet spells - the occurrence indicator has lag-1 autocorrelation
+    ~0.5 instead of Croston's i.i.d.-interval assumption.  The optimal
+    forecast is state-dependent: P(demand next step) is high right after
+    observed demand and decays through a quiet spell.  Models that estimate
+    a single average demand rate are systematically wrong in both states.
+    """
+    rng = _rng(seed)
+    sigma = np.sqrt(1.0 - phi**2)
+    z = _ar1(rng, T, phi, sigma)
+    occ = z > thresh
+    size = 1 + rng.poisson(2.0, size=T)
+    return (occ * size).astype(float)

--- a/tempus_bench/generators/intermittent_demand.py
+++ b/tempus_bench/generators/intermittent_demand.py
@@ -1,0 +1,32 @@
+"""Generator: intermittent_demand.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def intermittent_demand(T=DEFAULT_T, seed=None):
+    """Zero-inflated intermittent demand (Croston setting):
+
+        occurrence: o_t ~ Bernoulli(p_t),
+                    p_t = sigmoid(-1.2 + 0.8 sin(2 pi t/24))  (~0.12-0.4),
+        size:       s_t ~ 1 + Poisson(3),
+        y_t = o_t * s_t.
+
+    ~75% zeros with seasonally varying occurrence odds.  Per-step squared
+    error is minimised by p_t*E[s] (a fractional value!), not by the modal
+    zero - the classic intermittent-demand trap; also probes zero-inflation
+    handling in probabilistic outputs.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    p = 1.0 / (1.0 + np.exp(-(-1.2 + 0.8 * np.sin(2 * np.pi * t / PERIOD))))
+    occ = rng.random(T) < p
+    size = 1 + rng.poisson(3.0, size=T)
+    return (occ * size).astype(float)

--- a/tempus_bench/generators/irregular_period_seasonal.py
+++ b/tempus_bench/generators/irregular_period_seasonal.py
@@ -1,0 +1,32 @@
+"""Generator: irregular_period_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def irregular_period_seasonal(T=DEFAULT_T, seed=None, amp=10.0, sigma=1.0,
+                              mod_depth=0.3, mod_period=512.0):
+    """Frequency-modulated cycle with smoothly drifting period.
+
+    The instantaneous frequency f(t) = (1/24)*(1 + mod_depth*sin(2 pi t /
+    mod_period)) is integrated into a phase (phi_t = 2 pi * cumsum f), and
+
+        y_t = amp * sin(phi_t) + sigma*eps_t.
+
+    The local period therefore truly varies between ~18.5 and ~34 steps.
+    (Naively writing sin(2 pi t / p(t)) does NOT do this - the derivative
+    of t/p(t) is not 1/p(t) - hence the phase-accumulation construction.)
+    Tests phase tracking when the period cannot be assumed constant.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    freq = (1.0 / PERIOD) * (1.0 + mod_depth * np.sin(2 * np.pi * t / mod_period))
+    phase = 2 * np.pi * np.cumsum(freq)
+    return amp * np.sin(phase) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/level_shift.py
+++ b/tempus_bench/generators/level_shift.py
@@ -1,0 +1,27 @@
+"""Generator: level_shift.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng, _t
+
+
+def level_shift(T=DEFAULT_T, seed=None, frac_break=0.7, shift=6.0, sigma=1.0):
+    """One-off mean shift on the reference sinusoid:
+
+        y_t = 10 sin(2 pi t/24) + shift*1{t >= 0.7T} + sigma*eps_t.
+
+    A permanent +6 sigma level jump.  Post-break, the correct level is the
+    new one; models anchored to the full-context mean systematically bias
+    low.  (Under rolling windows, early windows also probe behaviour when
+    the break sits inside the forecast context at varying depths.)
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    return _base_signal(T) + shift * (t >= frac_break * T) \
+        + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/linear_trend.py
+++ b/tempus_bench/generators/linear_trend.py
@@ -1,0 +1,23 @@
+"""Generator: linear_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def linear_trend(T=DEFAULT_T, seed=None, a=10.0, b=20.0, sigma=1.0):
+    """Trend-stationary linear trend: y_t = a + b*(t/T) + sigma*eps_t.
+
+    Deterministic rise of 20 = 20 noise sds over the series.  Unlike the
+    random walk with drift, forecast uncertainty does NOT grow with horizon
+    (Bayes MSE = sigma^2 for all h) - the diagnostic pair for
+    trend- vs difference-stationarity.
+    """
+    rng = _rng(seed)
+    return a + b * (_t(T) / T) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/log_trend.py
+++ b/tempus_bench/generators/log_trend.py
@@ -1,0 +1,22 @@
+"""Generator: log_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def log_trend(T=DEFAULT_T, seed=None, base=2.0, c=2.0, sigma=0.5):
+    """Logarithmic (decelerating) trend: y_t = base + c*ln(1+t) + sigma*eps_t.
+
+    Growth without a finite asymptote but with ever-slowing increments;
+    naive linear extrapolation overshoots.  The baseline offset keeps the
+    series positive at early t despite additive noise.
+    """
+    rng = _rng(seed)
+    return base + c * np.log1p(_t(T)) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/logistic_map.py
+++ b/tempus_bench/generators/logistic_map.py
@@ -1,0 +1,38 @@
+"""Generator: logistic_map.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def logistic_map(T=DEFAULT_T, seed=None, r=3.9, obs_sigma=0.0):
+    """Chaotic logistic map: x_{t+1} = r x_t (1 - x_t), r=3.9, x in (0,1).
+
+        y_t = 10*x_t + obs_sigma*eps_t   (scaled to working amplitude).
+
+    Fully deterministic: one-step dynamics are exactly learnable (a smooth
+    quadratic map), but sensitivity to initial conditions (Lyapunov exponent
+    ~0.5) makes long horizons intrinsically unpredictable - point accuracy
+    must degrade toward the invariant distribution at a known exponential
+    rate.  Tests short-horizon nonlinear dynamics *and* long-horizon
+    uncertainty growth.  Initial condition drawn U(0.1, 0.9); 200-step
+    transient discarded.
+    """
+    rng = _rng(seed)
+    x = rng.uniform(0.1, 0.9)
+    for _ in range(200):
+        x = r * x * (1.0 - x)
+    out = np.empty(T)
+    for t in range(T):
+        x = r * x * (1.0 - x)
+        out[t] = x
+    y = 10.0 * out
+    if obs_sigma > 0:
+        y = y + obs_sigma * rng.standard_normal(T)
+    return y

--- a/tempus_bench/generators/logistic_trend.py
+++ b/tempus_bench/generators/logistic_trend.py
@@ -1,0 +1,29 @@
+"""Generator: logistic_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def logistic_trend(T=DEFAULT_T, seed=None, base=2.0, L=30.0, frac_mid=0.85,
+                   frac_width=0.2, sigma=0.5):
+    """Sigmoid (saturating) trend: y_t = base + L/(1 + exp(-k(t - t0))) + sigma*eps_t
+
+    with t0 = frac_mid*T and k = 4.4/(frac_width*T) (10%-90% transition
+    spans ~frac_width*T steps).  The inflection sits at 0.85*T, so rolling
+    evaluation windows successively face acceleration, inflection and
+    saturation - the property under test is recognising that apparent
+    exponential growth is about to saturate.  The baseline offset keeps the
+    series positive before the rise despite additive noise.
+    """
+    rng = _rng(seed)
+    t0 = frac_mid * T
+    k = 4.4 / (frac_width * T)
+    sig = L / (1.0 + np.exp(-k * (_t(T) - t0)))
+    return base + sig + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/lognormal_positive.py
+++ b/tempus_bench/generators/lognormal_positive.py
@@ -1,0 +1,29 @@
+"""Generator: lognormal_positive.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _ar1, _rng, _t
+
+
+def lognormal_positive(T=DEFAULT_T, seed=None):
+    """Strictly positive continuous series, multiplicative on every scale:
+
+        log y_t = 2 + 0.5*(t/T) + 0.4 sin(2 pi t/24) + u_t,
+        u_t = AR(1)(phi=0.7, sigma=0.2).
+
+    Level ~7 -> ~12 with conditionally log-normal noise: sd proportional to
+    level and right-skewed marginals.  The natural model is additive in
+    logs; tests whether a forecaster respects positivity (no negative
+    samples/intervals) and multiplicative error structure.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    logy = 2.0 + 0.5 * (t / T) + 0.4 * np.sin(2 * np.pi * t / PERIOD) \
+        + _ar1(rng, T, 0.7, 0.2)
+    return np.exp(logy)

--- a/tempus_bench/generators/long_memory_fgn.py
+++ b/tempus_bench/generators/long_memory_fgn.py
@@ -1,0 +1,43 @@
+"""Generator: long_memory_fgn.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def long_memory_fgn(T=DEFAULT_T, seed=None, H=0.9):
+    """Fractional Gaussian noise with Hurst H=0.9 (long memory).
+
+    Exact simulation via the Hosking/Durbin-Levinson recursion on the fGn
+    autocovariance gamma(k) = 0.5*(|k+1|^{2H} - 2|k|^{2H} + |k-1|^{2H}).
+    Autocorrelations decay hyperbolically (~ k^{2H-2} = k^{-0.2}); distant
+    context remains informative, and predictability decays much more slowly
+    with horizon than for any ARMA process.  Scaled by 3 for a working
+    amplitude comparable to other tasks.
+    """
+    rng = _rng(seed)
+    k = np.arange(T, dtype=float)
+    gamma = 0.5 * ((k + 1) ** (2 * H) - 2 * k ** (2 * H)
+                   + np.abs(k - 1) ** (2 * H))
+    x = np.empty(T)
+    v = gamma[0]
+    x[0] = rng.standard_normal() * np.sqrt(v)
+    phi_prev = np.zeros(0)
+    for t in range(1, T):
+        if t == 1:
+            kap = gamma[1] / v
+        else:
+            kap = (gamma[t] - phi_prev @ gamma[t - 1:0:-1]) / v
+        phi_new = np.empty(t)
+        phi_new[:t - 1] = phi_prev - kap * phi_prev[::-1]
+        phi_new[t - 1] = kap
+        v = v * (1.0 - kap ** 2)
+        x[t] = phi_new @ x[t - 1::-1] + np.sqrt(v) * rng.standard_normal()
+        phi_prev = phi_new
+    return 3.0 * x

--- a/tempus_bench/generators/low_snr_seasonal.py
+++ b/tempus_bench/generators/low_snr_seasonal.py
@@ -1,0 +1,25 @@
+"""Generator: low_snr_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def low_snr_seasonal(T=DEFAULT_T, seed=None, amp=1.0, sigma=2.0):
+    """Weak sinusoid buried in noise: y_t = amp*sin(2 pi t/24) + sigma*eps_t.
+
+    Signal-to-noise ratio (variance) = amp^2/2 / sigma^2 = 0.125.  With ~85
+    full cycles in the context the seasonal component is statistically
+    recoverable (periodogram peak >> noise floor), so a good model should
+    beat the unconditional mean; a model that gives up and predicts the
+    mean loses amp^2/2 of explainable variance.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    return amp * np.sin(2 * np.pi * t / PERIOD) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/lumpy_demand.py
+++ b/tempus_bench/generators/lumpy_demand.py
@@ -1,0 +1,32 @@
+"""Generator: lumpy_demand.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def lumpy_demand(T=DEFAULT_T, seed=None, p=0.08, mu=1.0, s=1.0):
+    """Lumpy demand (Syntetos-Boylan 'lumpy' quadrant): rare occurrences
+    AND highly variable sizes:
+
+        o_t ~ Bernoulli(0.08) i.i.d.  (average inter-demand interval 12.5),
+        s_t = ceil(LogNormal(mu=1.0, sigma=1.0))  (heavy-tailed, CV^2 ~ 1.7),
+        y_t = o_t * s_t.
+
+    ~92% zeros with sizes ranging from 1 to occasional ~40-unit spikes.
+    Complements intermittent_demand (frequent-ish occurrences, low size
+    variability): here BOTH the timing and the magnitude are hard, the
+    regime where point forecasts are least informative and probabilistic
+    (quantile) forecasts carry all the value.  A 512-step context still
+    contains ~41 demand events, so the size distribution is estimable.
+    """
+    rng = _rng(seed)
+    occ = rng.random(T) < p
+    size = np.ceil(rng.lognormal(mean=mu, sigma=s, size=T))
+    return (occ * size).astype(float)

--- a/tempus_bench/generators/ma1.py
+++ b/tempus_bench/generators/ma1.py
@@ -1,0 +1,24 @@
+"""Generator: ma1.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def ma1(T=DEFAULT_T, seed=None, theta=0.8, sigma=1.0):
+    """Invertible MA(1): y_t = eps_t + theta*eps_{t-1}, eps ~ N(0, sigma^2).
+
+    Memory of exactly one lag: the Bayes forecast is non-trivial at horizon
+    1 (E[y_{t+1}|F_t] = theta*eps_t) and exactly 0 for horizons >= 2.  Tests
+    both short-memory exploitation and the calibration to *stop* predicting
+    beyond the memory of the process.
+    """
+    rng = _rng(seed)
+    eps = rng.standard_normal(T + 1) * sigma
+    return eps[1:] + theta * eps[:-1]

--- a/tempus_bench/generators/mackey_glass.py
+++ b/tempus_bench/generators/mackey_glass.py
@@ -1,0 +1,40 @@
+"""Generator: mackey_glass.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def mackey_glass(T=DEFAULT_T, seed=None, tau=17.0, beta=0.2, gamma=0.1,
+                 n_exp=10, dt=0.1, stride=10):
+    """Mackey-Glass delay differential equation (chaotic regime, tau=17):
+
+        dx/dt = beta * x(t-tau) / (1 + x(t-tau)^n) - gamma * x(t),
+
+    integrated by Euler with step dt=0.1 and sub-sampled every ``stride``
+    steps (sampling interval 1 time unit - the standard benchmark setup).
+    History initialised at 1.2 plus a small seeded perturbation; the first
+    500 time units are discarded as transient.  Smooth quasi-periodic
+    chaotic oscillations: strong short-range predictability with slow
+    divergence - the classic nonlinear-forecasting benchmark, complementary
+    to the logistic map (continuous & smooth vs discrete & jagged).
+    Scaled by 10.
+    """
+    rng = _rng(seed)
+    hist = int(round(tau / dt))
+    discard_units = 500
+    n_steps = hist + (discard_units + T) * stride
+    x = np.empty(n_steps)
+    x[:hist] = 1.2 + 0.05 * rng.standard_normal()
+    for i in range(hist, n_steps):
+        xd = x[i - hist]
+        x[i] = x[i - 1] + dt * (beta * xd / (1.0 + xd ** n_exp)
+                                - gamma * x[i - 1])
+    series = x[hist + discard_units * stride::stride][:T]
+    return 10.0 * series

--- a/tempus_bench/generators/markov_switching_ar.py
+++ b/tempus_bench/generators/markov_switching_ar.py
@@ -1,0 +1,37 @@
+"""Generator: markov_switching_ar.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def markov_switching_ar(T=DEFAULT_T, seed=None, p_stay=0.97, sigma=0.5):
+    """Recurring regimes: 2-state Markov chain (stay prob 0.97, mean sojourn
+    ~33 steps) switching the mean and dynamics of an AR(1):
+
+        state 0:  y_t = -1.5 + 0.5*(y_{t-1}+1.5) + sigma*eps_t
+        state 1:  y_t = +1.5 + 0.9*(y_{t-1}-1.5) + sigma*eps_t
+
+    Unlike one-off breaks, regimes recur (~60 switches per series), so the
+    regime structure is identifiable from context and the optimal forecast
+    is a probability-weighted mixture over future regime paths.  Burn-in
+    applied.
+    """
+    rng = _rng(seed)
+    n = T + BURN_IN
+    mu = (-1.5, 1.5)
+    phi = (0.5, 0.9)
+    s = rng.integers(0, 2)
+    y = np.zeros(n)
+    for t in range(1, n):
+        if rng.random() > p_stay:
+            s = 1 - s
+        y[t] = mu[s] + phi[s] * (y[t - 1] - mu[s]) \
+            + sigma * rng.standard_normal()
+    return y[BURN_IN:]

--- a/tempus_bench/generators/mean_reverting_ar1.py
+++ b/tempus_bench/generators/mean_reverting_ar1.py
@@ -1,0 +1,20 @@
+"""Generator: mean_reverting_ar1.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def mean_reverting_ar1(T=DEFAULT_T, seed=None, phi=0.8, sigma=1.0):
+    """Stationary AR(1), phi=0.8: strongly mean-reverting level.
+
+    Bayes forecast decays geometrically to the mean: E[y_{t+h}|y_t] =
+    phi^h y_t.  The canonical "stationary movement" task.
+    """
+    return _ar1(_rng(seed), T, phi, sigma)

--- a/tempus_bench/generators/measurement_error_rw.py
+++ b/tempus_bench/generators/measurement_error_rw.py
@@ -1,0 +1,29 @@
+"""Generator: measurement_error_rw.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def measurement_error_rw(T=DEFAULT_T, seed=None, sigma_proc=0.3,
+                         sigma_obs=1.0):
+    """Local-level state-space model (signal + measurement error):
+
+        x_t = x_{t-1} + sigma_proc * w_t     (latent level, random walk),
+        y_t = x_t + sigma_obs * v_t          (noisy observation).
+
+    Signal-to-measurement ratio q = (sigma_proc/sigma_obs)^2 = 0.09.  The
+    Bayes forecast is the Kalman-filtered level (equivalently exponential
+    smoothing with the steady-state gain ~0.26) - neither the last
+    observation (too noisy) nor a long mean (too stale).  This is the
+    "measurement error" data-quality task, distinct from process noise.
+    """
+    rng = _rng(seed)
+    x = np.cumsum(sigma_proc * rng.standard_normal(T))
+    return x + sigma_obs * rng.standard_normal(T)

--- a/tempus_bench/generators/metadata.json
+++ b/tempus_bench/generators/metadata.json
@@ -1,0 +1,873 @@
+{
+  "iid_gaussian": {
+    "generator_id": 1,
+    "function": "iid_gaussian",
+    "primary_category": "noise",
+    "categories": [
+      "noise",
+      "stationarity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "White noise: y_t ~ iid N(mu, sigma^2).",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "noise_free_composite": {
+    "generator_id": 2,
+    "function": "noise_free_composite",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Deterministic, noise-free signal: trend + two incommensurate sines.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "low_snr_seasonal": {
+    "generator_id": 3,
+    "function": "low_snr_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Weak sinusoid buried in noise: y_t = amp*sin(2 pi t/24) + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "ma1": {
+    "generator_id": 4,
+    "function": "ma1",
+    "primary_category": "memory",
+    "categories": [
+      "memory",
+      "stationarity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Invertible MA(1): y_t = eps_t + theta*eps_{t-1}, eps ~ N(0, sigma^2).",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "mean_reverting_ar1": {
+    "generator_id": 5,
+    "function": "mean_reverting_ar1",
+    "primary_category": "stationarity",
+    "categories": [
+      "stationarity",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Stationary AR(1), phi=0.8: strongly mean-reverting level.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "near_unit_root_ar1": {
+    "generator_id": 6,
+    "function": "near_unit_root_ar1",
+    "primary_category": "stationarity",
+    "categories": [
+      "stationarity",
+      "memory",
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "AR(1) with phi=0.995: stationary but nearly integrated.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "random_walk": {
+    "generator_id": 7,
+    "function": "random_walk",
+    "primary_category": "trend",
+    "categories": [
+      "trend",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Driftless random walk: y_t = y_{t-1} + sigma*eps_t, y_0 = 0.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "random_walk_drift": {
+    "generator_id": 8,
+    "function": "random_walk_drift",
+    "primary_category": "trend",
+    "categories": [
+      "trend",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Random walk with drift: y_t = drift + y_{t-1} + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "linear_trend": {
+    "generator_id": 9,
+    "function": "linear_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Trend-stationary linear trend: y_t = a + b*(t/T) + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "exponential_trend": {
+    "generator_id": 10,
+    "function": "exponential_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Exponential growth: y_t = y0 * growth^(t/T) + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "log_trend": {
+    "generator_id": 11,
+    "function": "log_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Logarithmic (decelerating) trend: y_t = base + c*ln(1+t) + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "power_trend": {
+    "generator_id": 12,
+    "function": "power_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Power-law (\"p-root\") trend: y_t = base + scale*(t/T)^p + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "logistic_trend": {
+    "generator_id": 13,
+    "function": "logistic_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend",
+      "nonlinearity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Sigmoid (saturating) trend: y_t = base + L/(1 + exp(-k(t - t0))) + sigma*eps_t",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "piecewise_linear_trend": {
+    "generator_id": 14,
+    "function": "piecewise_linear_trend",
+    "primary_category": "trend",
+    "categories": [
+      "trend",
+      "structural_change"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Broken trend: slope b1/T before the break at frac_break*T, b2/T after (continuous at the break), plus N(0, sigma^2) noise.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "sinusoidal_seasonal": {
+    "generator_id": 15,
+    "function": "sinusoidal_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "stationarity",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Pure stationary cycle: y_t = amp*sin(2 pi t/period) + sigma*eps_t.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "multi_seasonal": {
+    "generator_id": 16,
+    "function": "multi_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Two nested periods (daily-in-weekly analogue)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "nonsinusoidal_seasonal": {
+    "generator_id": 17,
+    "function": "nonsinusoidal_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Sharp, asymmetric periodic shape (exponentiated-sine \"spike train\")",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "trend_seasonal_additive": {
+    "generator_id": 18,
+    "function": "trend_seasonal_additive",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "trend",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Non-stationary cyclical, additive composition",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "trend_seasonal_multiplicative": {
+    "generator_id": 19,
+    "function": "trend_seasonal_multiplicative",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "trend",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Non-stationary cyclical, multiplicative composition",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "damped_seasonal": {
+    "generator_id": 20,
+    "function": "damped_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Regressive (decaying-amplitude) cycle",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "irregular_period_seasonal": {
+    "generator_id": 21,
+    "function": "irregular_period_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Frequency-modulated cycle with smoothly drifting period.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "evolving_seasonal": {
+    "generator_id": 22,
+    "function": "evolving_seasonal",
+    "primary_category": "seasonality",
+    "categories": [
+      "seasonality",
+      "structural_change"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Slowly morphing seasonal shape via drifting Fourier coefficients.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "heteroskedastic_level": {
+    "generator_id": 23,
+    "function": "heteroskedastic_level",
+    "primary_category": "noise",
+    "categories": [
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Level-dependent (multiplicative-style) heteroskedasticity",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "heteroskedastic_time": {
+    "generator_id": 24,
+    "function": "heteroskedastic_time",
+    "primary_category": "noise",
+    "categories": [
+      "noise",
+      "structural_change"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Time-driven variance growth: y_t = 10 sin(2 pi t/24) + sigma(t)*eps_t, with sigma(t) = sigma0 + (sigma1-sigma0)*(t/T) rising 0.5 -> 2.5.",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "garch_noise": {
+    "generator_id": 25,
+    "function": "garch_noise",
+    "primary_category": "noise",
+    "categories": [
+      "noise",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "GARCH(1,1) with zero conditional mean (volatility clustering)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "heavy_tailed_noise": {
+    "generator_id": 26,
+    "function": "heavy_tailed_noise",
+    "primary_category": "noise",
+    "categories": [
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Student-t(3) innovations on the reference sinusoid",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "skewed_noise": {
+    "generator_id": 27,
+    "function": "skewed_noise",
+    "primary_category": "noise",
+    "categories": [
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Right-skewed innovations (centred, unit-variance log-normal)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "autocorrelated_noise": {
+    "generator_id": 28,
+    "function": "autocorrelated_noise",
+    "primary_category": "noise",
+    "categories": [
+      "noise",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "AR(1) errors around a deterministic sinusoid",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "outlier_contaminated": {
+    "generator_id": 29,
+    "function": "outlier_contaminated",
+    "primary_category": "noise",
+    "categories": [
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Additive-outlier contamination of the reference sinusoid",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "measurement_error_rw": {
+    "generator_id": 30,
+    "function": "measurement_error_rw",
+    "primary_category": "noise",
+    "categories": [
+      "noise",
+      "memory",
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Local-level state-space model (signal + measurement error)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "ar2_pseudocyclic": {
+    "generator_id": 31,
+    "function": "ar2_pseudocyclic",
+    "primary_category": "memory",
+    "categories": [
+      "memory",
+      "seasonality",
+      "stationarity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Stationary AR(2) with complex roots (stochastic pseudo-cycles)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "long_memory_fgn": {
+    "generator_id": 32,
+    "function": "long_memory_fgn",
+    "primary_category": "memory",
+    "categories": [
+      "memory",
+      "stationarity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Fractional Gaussian noise with Hurst H=0.9 (long memory).",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "setar": {
+    "generator_id": 33,
+    "function": "setar",
+    "primary_category": "nonlinearity",
+    "categories": [
+      "nonlinearity",
+      "memory",
+      "structural_change"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Self-exciting threshold AR with asymmetric persistence (threshold 0)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "logistic_map": {
+    "generator_id": 34,
+    "function": "logistic_map",
+    "primary_category": "nonlinearity",
+    "categories": [
+      "nonlinearity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Chaotic logistic map: x_{t+1} = r x_t (1 - x_t), r=3.9, x in (0,1).",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 20,
+    "normalization_method": "none"
+  },
+  "mackey_glass": {
+    "generator_id": 35,
+    "function": "mackey_glass",
+    "primary_category": "nonlinearity",
+    "categories": [
+      "nonlinearity",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Mackey-Glass delay differential equation (chaotic regime, tau=17)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "level_shift": {
+    "generator_id": 36,
+    "function": "level_shift",
+    "primary_category": "structural_change",
+    "categories": [
+      "structural_change",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "One-off mean shift on the reference sinusoid",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "variance_shift": {
+    "generator_id": 37,
+    "function": "variance_shift",
+    "primary_category": "structural_change",
+    "categories": [
+      "structural_change",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "One-off variance break: sigma jumps 1.0 -> 2.5 at 0.6T on the reference sinusoid (conditional mean unchanged).",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "markov_switching_ar": {
+    "generator_id": 38,
+    "function": "markov_switching_ar",
+    "primary_category": "structural_change",
+    "categories": [
+      "structural_change",
+      "memory",
+      "nonlinearity"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_real",
+    "description": "Recurring regimes: 2-state Markov chain (stay prob 0.97, mean sojourn ~33 steps) switching the mean and dynamics of an AR(1)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "binary_latent_ar": {
+    "generator_id": 39,
+    "function": "binary_latent_ar",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "seasonality",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "binary",
+    "description": "Binary series from a thresholded latent process",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "ordinal_categorical": {
+    "generator_id": 40,
+    "function": "ordinal_categorical",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "seasonality",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "categorical_ordinal",
+    "description": "Ordered 3-category series: the same latent construction as binary_latent_ar, cut at thresholds (-0.8, +0.8)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "poisson_counts": {
+    "generator_id": 41,
+    "function": "poisson_counts",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "seasonality",
+      "trend"
+    ],
+    "variate": "univariate",
+    "target_type": "count_positive",
+    "description": "Non-negative counts, canonical log-link Poisson",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "negbin_counts": {
+    "generator_id": 42,
+    "function": "negbin_counts",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "count_positive",
+    "description": "Overdispersed counts via a Gamma-Poisson (negative binomial) mixture with the same mean path as poisson_counts",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "skellam_integer": {
+    "generator_id": 43,
+    "function": "skellam_integer",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "count_signed",
+    "description": "Signed integers (difference of two seasonal Poisson flows)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "lognormal_positive": {
+    "generator_id": 44,
+    "function": "lognormal_positive",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "noise",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_positive",
+    "description": "Strictly positive continuous series, multiplicative on every scale",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "intermittent_demand": {
+    "generator_id": 45,
+    "function": "intermittent_demand",
+    "primary_category": "target_type",
+    "categories": [
+      "target_type",
+      "intermittency",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "count_positive",
+    "description": "Zero-inflated intermittent demand (Croston setting)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "intermittent_bursty": {
+    "generator_id": 46,
+    "function": "intermittent_bursty",
+    "primary_category": "intermittency",
+    "categories": [
+      "intermittency",
+      "target_type",
+      "memory"
+    ],
+    "variate": "univariate",
+    "target_type": "count_positive",
+    "description": "Intermittent demand with serially dependent occurrence",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "lumpy_demand": {
+    "generator_id": 47,
+    "function": "lumpy_demand",
+    "primary_category": "intermittency",
+    "categories": [
+      "intermittency",
+      "target_type",
+      "noise"
+    ],
+    "variate": "univariate",
+    "target_type": "count_positive",
+    "description": "Lumpy demand (Syntetos-Boylan 'lumpy' quadrant): rare occurrences AND highly variable sizes",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "zero_inflated_continuous": {
+    "generator_id": 48,
+    "function": "zero_inflated_continuous",
+    "primary_category": "intermittency",
+    "categories": [
+      "intermittency",
+      "target_type",
+      "seasonality"
+    ],
+    "variate": "univariate",
+    "target_type": "continuous_zero_inflated",
+    "description": "Zero-inflated *continuous* series (precipitation analogue)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "none"
+  },
+  "mv_correlated_noise": {
+    "generator_id": 49,
+    "function": "mv_correlated_noise",
+    "primary_category": "multivariate",
+    "categories": [
+      "multivariate",
+      "noise"
+    ],
+    "variate": "multivariate",
+    "target_type": "continuous_real",
+    "description": "m AR(1) series with strongly correlated innovations (returns (T, m))",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "mv_var": {
+    "generator_id": 50,
+    "function": "mv_var",
+    "primary_category": "multivariate",
+    "categories": [
+      "multivariate",
+      "memory"
+    ],
+    "variate": "multivariate",
+    "target_type": "continuous_real",
+    "description": "Bivariate VAR(1) with genuine cross-dynamics (returns (T, 2))",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "mv_leadlag": {
+    "generator_id": 51,
+    "function": "mv_leadlag",
+    "primary_category": "multivariate",
+    "categories": [
+      "multivariate",
+      "covariate",
+      "memory"
+    ],
+    "variate": "multivariate",
+    "target_type": "continuous_real",
+    "description": "Leading indicator: x leads y by lag steps (returns (T, 2) = [y, x])",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 16,
+    "normalization_method": "standard"
+  },
+  "mv_common_factor": {
+    "generator_id": 52,
+    "function": "mv_common_factor",
+    "primary_category": "multivariate",
+    "categories": [
+      "multivariate",
+      "memory"
+    ],
+    "variate": "multivariate",
+    "target_type": "continuous_real",
+    "description": "Factor structure: m=4 series driven by one latent AR(1) factor (returns (T, 4))",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "mv_cointegrated": {
+    "generator_id": 53,
+    "function": "mv_cointegrated",
+    "primary_category": "multivariate",
+    "categories": [
+      "multivariate",
+      "trend",
+      "memory"
+    ],
+    "variate": "multivariate",
+    "target_type": "continuous_real",
+    "description": "Cointegrated pair sharing one stochastic trend (returns (T, 2))",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  },
+  "covariate_nonlinear": {
+    "generator_id": 54,
+    "function": "covariate_nonlinear",
+    "primary_category": "covariate",
+    "categories": [
+      "covariate",
+      "nonlinearity",
+      "seasonality"
+    ],
+    "variate": "covariate",
+    "target_type": "continuous_real",
+    "description": "Covariate-driven target with a nonlinear, lagged link (returns (T, 2) = [y, x]; x is the covariate, known over context+horizon per the TempusBench task definition)",
+    "default_series_length": 2048,
+    "context_window": 512,
+    "forecast_horizon": 64,
+    "normalization_method": "standard"
+  }
+}

--- a/tempus_bench/generators/multi_seasonal.py
+++ b/tempus_bench/generators/multi_seasonal.py
@@ -1,0 +1,28 @@
+"""Generator: multi_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, LONG_PERIOD, PERIOD, _rng, _t
+
+
+def multi_seasonal(T=DEFAULT_T, seed=None, sigma=1.0):
+    """Two nested periods (daily-in-weekly analogue):
+
+        y_t = 6 sin(2 pi t/24) + 4 sin(2 pi t/168) + sigma*eps_t.
+
+    168 = 7*24, so the short cycle nests in the long one.  Tests whether a
+    model separates superposed periodicities; a single-period model leaves
+    the amplitude-4 component (variance 8) unexplained.  For the long cycle
+    to matter, use context >= 512 (3 weekly cycles).
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    return 6.0 * np.sin(2 * np.pi * t / PERIOD) \
+        + 4.0 * np.sin(2 * np.pi * t / LONG_PERIOD) \
+        + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/mv_cointegrated.py
+++ b/tempus_bench/generators/mv_cointegrated.py
@@ -1,0 +1,31 @@
+"""Generator: mv_cointegrated.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def mv_cointegrated(T=DEFAULT_T, seed=None):
+    """Cointegrated pair sharing one stochastic trend (returns (T, 2)):
+
+        w_t = w_{t-1} + eps_t (random walk);
+        y1_t = w_t + u1_t,   y2_t = 0.7 w_t + u2_t,
+        u_i = AR(1)(0.5, 0.5) stationary.
+
+    Each series alone is a unit-root process, but the spread y1 - y2/0.7
+    is stationary: deviations between the series are temporary and
+    forecastably close.  Tests whether a multivariate model exploits the
+    error-correction structure (forecasting the *pair* coherently) instead
+    of forecasting two independent random walks.
+    """
+    rng = _rng(seed)
+    w = np.cumsum(rng.standard_normal(T))
+    y1 = w + _ar1(rng, T, 0.5, 0.5)
+    y2 = 0.7 * w + _ar1(rng, T, 0.5, 0.5)
+    return np.column_stack([y1, y2])

--- a/tempus_bench/generators/mv_common_factor.py
+++ b/tempus_bench/generators/mv_common_factor.py
@@ -1,0 +1,33 @@
+"""Generator: mv_common_factor.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def mv_common_factor(T=DEFAULT_T, seed=None, m=4):
+    """Factor structure: m=4 series driven by one latent AR(1) factor
+    (returns (T, 4)):
+
+        f_t = 0.9 f_{t-1} + eps_t;   y_it = loading_i * f_t + u_it,
+        loadings = (1.0, 0.8, -0.6, 0.5);  u_it = AR(1)(0.4, 1.0) idiosync.
+
+    The common factor carries ~70% of total panel variance - dominant but
+    not trivially so.  Cross-sectional averaging de-noises the factor: the
+    panel reveals f_t more precisely than any single series does, so pooled
+    forecasts strictly beat per-series univariate ones.  Tests factor
+    extraction / cross-sectional information pooling.
+    """
+    rng = _rng(seed)
+    loadings = np.array([1.0, 0.8, -0.6, 0.5])
+    f = _ar1(rng, T, 0.9, 1.0)
+    out = np.empty((T, m))
+    for i in range(m):
+        out[:, i] = loadings[i] * f + _ar1(rng, T, 0.4, 1.0)
+    return out

--- a/tempus_bench/generators/mv_correlated_noise.py
+++ b/tempus_bench/generators/mv_correlated_noise.py
@@ -1,0 +1,35 @@
+"""Generator: mv_correlated_noise.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def mv_correlated_noise(T=DEFAULT_T, seed=None, m=3, phi=0.7, rho=0.8):
+    """m AR(1) series with strongly correlated innovations (returns (T, m)):
+
+        x_t = phi * x_{t-1} + e_t,   e_t ~ N(0, Sigma),
+        Sigma_ij = rho^{|i != j|}   (equicorrelation 0.8).
+
+    Because the transition is diagonal, the conditional MEAN of each series
+    given the joint past equals its univariate forecast - contemporaneous
+    correlation adds nothing to point accuracy.  What it does change is the
+    joint predictive distribution.  This task therefore tests joint/
+    probabilistic calibration specifically; a gap between a model's
+    univariate and multivariate point scores here signals confusion, not
+    skill.
+    """
+    rng = _rng(seed)
+    cov = np.full((m, m), rho) + (1.0 - rho) * np.eye(m)
+    L = np.linalg.cholesky(cov)
+    e = rng.standard_normal((T + BURN_IN, m)) @ L.T
+    x = np.zeros((T + BURN_IN, m))
+    for t in range(1, T + BURN_IN):
+        x[t] = phi * x[t - 1] + e[t]
+    return x[BURN_IN:]

--- a/tempus_bench/generators/mv_leadlag.py
+++ b/tempus_bench/generators/mv_leadlag.py
@@ -1,0 +1,31 @@
+"""Generator: mv_leadlag.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def mv_leadlag(T=DEFAULT_T, seed=None, lag=8, beta=1.0, sigma_y=0.3,
+               phi=0.95, sigma_x=1.0):
+    """Leading indicator: x leads y by ``lag`` steps (returns (T, 2) =
+    [y, x]):
+
+        x_t = 0.95 x_{t-1} + eps_t,      y_t = beta * x_{t-lag} + 0.3 nu_t.
+
+    For horizons h <= lag, y_{t+h} is (up to small noise) *already visible*
+    in x's context - the multivariate Bayes MSE is 0.09 while the best
+    univariate forecast inherits x's innovation variance.  The purest test
+    that a model exploits cross-series lead-lag information; with h > lag
+    the advantage decays, so keep lag >= h/2 relative to the task horizon.
+    """
+    rng = _rng(seed)
+    x_full = _ar1(rng, T + lag, phi, sigma_x)
+    x = x_full[lag:]
+    y = beta * x_full[:T] + sigma_y * rng.standard_normal(T)
+    return np.column_stack([y, x])

--- a/tempus_bench/generators/mv_var.py
+++ b/tempus_bench/generators/mv_var.py
@@ -1,0 +1,32 @@
+"""Generator: mv_var.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def mv_var(T=DEFAULT_T, seed=None, sigma=0.5):
+    """Bivariate VAR(1) with genuine cross-dynamics (returns (T, 2)):
+
+        x_t = A x_{t-1} + e_t,  A = [[0.7, 0.25], [-0.2, 0.6]],
+        e_t ~ N(0, sigma^2 I).
+
+    Eigenvalues of A are complex with modulus ~0.69 (stationary, damped
+    rotational dynamics).  Each series Granger-causes the other, so the
+    optimal forecast of either series requires both histories - the
+    canonical test that a multivariate model actually uses cross-series
+    lags.
+    """
+    rng = _rng(seed)
+    A = np.array([[0.7, 0.25], [-0.2, 0.6]])
+    x = np.zeros((T + BURN_IN, 2))
+    e = sigma * rng.standard_normal((T + BURN_IN, 2))
+    for t in range(1, T + BURN_IN):
+        x[t] = A @ x[t - 1] + e[t]
+    return x[BURN_IN:]

--- a/tempus_bench/generators/near_unit_root_ar1.py
+++ b/tempus_bench/generators/near_unit_root_ar1.py
@@ -1,0 +1,23 @@
+"""Generator: near_unit_root_ar1.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _ar1, _rng
+
+
+def near_unit_root_ar1(T=DEFAULT_T, seed=None, phi=0.995, sigma=1.0):
+    """AR(1) with phi=0.995: stationary but nearly integrated.
+
+    Discriminates models that over-difference (treat as random walk => flat
+    forecasts, ignoring slow reversion) from those that over-mean-revert.
+    Stationary sd = sigma/sqrt(1-phi^2) ~= 10; mean-reversion half-life
+    ln(0.5)/ln(phi) ~= 138 steps, i.e. reversion is visible across a
+    512-step context but negligible within a 64-step horizon.
+    """
+    return _ar1(_rng(seed), T, phi, sigma)

--- a/tempus_bench/generators/negbin_counts.py
+++ b/tempus_bench/generators/negbin_counts.py
@@ -1,0 +1,30 @@
+"""Generator: negbin_counts.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def negbin_counts(T=DEFAULT_T, seed=None, r=3.0):
+    """Overdispersed counts via a Gamma-Poisson (negative binomial) mixture
+    with the same mean path as poisson_counts:
+
+        mu_t as in poisson_counts;  g_t ~ Gamma(r, mu_t/r);
+        y_t ~ Poisson(g_t)   =>   Var = mu_t + mu_t^2 / r.
+
+    With r=3, variance is up to ~5x the Poisson variance at the same mean.
+    The paired contrast poisson_counts vs negbin_counts isolates
+    overdispersion: point forecasts should coincide, predictive intervals
+    must not.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    mu = np.exp(1.5 + 0.4 * (t / T) + 0.7 * np.sin(2 * np.pi * t / PERIOD))
+    g = rng.gamma(shape=r, scale=mu / r)
+    return rng.poisson(g).astype(float)

--- a/tempus_bench/generators/noise_free_composite.py
+++ b/tempus_bench/generators/noise_free_composite.py
@@ -1,0 +1,27 @@
+"""Generator: noise_free_composite.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _t
+
+
+def noise_free_composite(T=DEFAULT_T, seed=None):
+    """Deterministic, noise-free signal: trend + two incommensurate sines.
+
+        y_t = 0.004 t + 6 sin(2 pi t / 24) + 3 sin(2 pi t / 41)
+
+    (24 and 41 are coprime, so the joint pattern repeats only every 984
+    steps.)  The Bayes error is exactly zero: this measures a model's
+    precision ceiling and its ability to represent superposed periodicities
+    without the excuse of noise.  ``seed`` is accepted for interface
+    uniformity but unused.
+    """
+    t = _t(T)
+    return 0.004 * t + 6.0 * np.sin(2 * np.pi * t / PERIOD) \
+        + 3.0 * np.sin(2 * np.pi * t / 41.0)

--- a/tempus_bench/generators/nonsinusoidal_seasonal.py
+++ b/tempus_bench/generators/nonsinusoidal_seasonal.py
@@ -1,0 +1,30 @@
+"""Generator: nonsinusoidal_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def nonsinusoidal_seasonal(T=DEFAULT_T, seed=None, kappa=2.0, sigma=1.0):
+    """Sharp, asymmetric periodic shape (exponentiated-sine "spike train"):
+
+        s(t) = exp(kappa*[sin(w t) + 0.5 sin(2 w t)]),  w = 2 pi / 24,
+        y_t  = 10 * (s(t) - mean(s)) / (max(s) - min(s)) * 2 + sigma*eps_t.
+
+    The pattern is peaked and left-right asymmetric - deliberately far from
+    a sinusoid - normalised to amplitude ~10.  Tests seasonal *shape*
+    fidelity: a Fourier-truncated or smoothness-biased model rounds off the
+    peaks, which the per-step metrics punish.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    w = 2 * np.pi / PERIOD
+    s = np.exp(kappa * (np.sin(w * t) + 0.5 * np.sin(2 * w * t)))
+    s = (s - s.mean()) / (s.max() - s.min()) * 20.0
+    return s + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/ordinal_categorical.py
+++ b/tempus_bench/generators/ordinal_categorical.py
@@ -1,0 +1,26 @@
+"""Generator: ordinal_categorical.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _ar1, _rng, _t
+
+
+def ordinal_categorical(T=DEFAULT_T, seed=None, phi=0.9, sigma=0.4, amp=1.5):
+    """Ordered 3-category series: the same latent construction as
+    binary_latent_ar, cut at thresholds (-0.8, +0.8):
+
+        y_t = 0 if z_t <= -0.8;  1 if -0.8 < z_t <= 0.8;  2 otherwise.
+
+    Covers the 'categorical' target type of the TempusBench taxonomy with
+    an ordered state space (unordered categories have no natural error
+    metric under MAE/RMSE-style evaluation).
+    """
+    rng = _rng(seed)
+    z = _ar1(rng, T, phi, sigma) + amp * np.sin(2 * np.pi * _t(T) / PERIOD)
+    return np.digitize(z, (-0.8, 0.8)).astype(float)

--- a/tempus_bench/generators/outlier_contaminated.py
+++ b/tempus_bench/generators/outlier_contaminated.py
@@ -1,0 +1,31 @@
+"""Generator: outlier_contaminated.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng
+
+
+def outlier_contaminated(T=DEFAULT_T, seed=None, p=0.02, out_scale=10.0,
+                         sigma=1.0):
+    """Additive-outlier contamination of the reference sinusoid:
+
+        y_t = 10 sin(2 pi t/24) + sigma*eps_t + o_t,
+        o_t = 0 w.p. 1-p;  +/- U(8, 15)*sigma w.p. p (sign fair-coin).
+
+    Isolated impulses (~2% of points) that carry no information about the
+    future.  A robust model ignores them; a fragile context encoding lets a
+    single spike distort level/seasonal estimates.
+    """
+    rng = _rng(seed)
+    y = _base_signal(T) + sigma * rng.standard_normal(T)
+    mask = rng.random(T) < p
+    n_out = int(mask.sum())
+    signs = rng.choice([-1.0, 1.0], size=n_out)
+    y[mask] += signs * rng.uniform(8.0, 15.0, size=n_out) * sigma
+    return y

--- a/tempus_bench/generators/piecewise_linear_trend.py
+++ b/tempus_bench/generators/piecewise_linear_trend.py
@@ -1,0 +1,26 @@
+"""Generator: piecewise_linear_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def piecewise_linear_trend(T=DEFAULT_T, seed=None, frac_break=0.6,
+                           b1=15.0, b2=-10.0, sigma=1.0):
+    """Broken trend: slope b1/T before the break at frac_break*T, b2/T after
+    (continuous at the break), plus N(0, sigma^2) noise.
+
+    A slope *reversal* (up then down).  Tests whether a model conditions on
+    the post-break regime instead of the full-context average slope.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    tb = frac_break * T
+    trend = np.where(t <= tb, b1 * t / T, b1 * tb / T + b2 * (t - tb) / T)
+    return 5.0 + trend + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/poisson_counts.py
+++ b/tempus_bench/generators/poisson_counts.py
@@ -1,0 +1,27 @@
+"""Generator: poisson_counts.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def poisson_counts(T=DEFAULT_T, seed=None):
+    """Non-negative counts, canonical log-link Poisson:
+
+        lambda_t = exp(1.5 + 0.4*(t/T) + 0.7 sin(2 pi t/24)),
+        y_t ~ Poisson(lambda_t)     (lambda ranges ~2.2 -> ~13.5).
+
+    Equidispersed (Var = mean).  Discreteness, positivity, and the
+    mean-variance link distinguish count data from continuous data; the
+    Bayes point forecast is lambda_t (mean) or the Poisson median.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    lam = np.exp(1.5 + 0.4 * (t / T) + 0.7 * np.sin(2 * np.pi * t / PERIOD))
+    return rng.poisson(lam).astype(float)

--- a/tempus_bench/generators/power_trend.py
+++ b/tempus_bench/generators/power_trend.py
@@ -1,0 +1,23 @@
+"""Generator: power_trend.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng, _t
+
+
+def power_trend(T=DEFAULT_T, seed=None, base=2.0, scale=10.0, p=0.5,
+                sigma=0.5):
+    """Power-law ("p-root") trend: y_t = base + scale*(t/T)^p + sigma*eps_t.
+
+    With p=0.5, concave sub-linear growth; increments decay like t^(p-1).
+    Intermediate between linear and logarithmic deceleration.  The baseline
+    offset keeps the series positive at early t despite additive noise.
+    """
+    rng = _rng(seed)
+    return base + scale * np.power(_t(T) / T, p) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/random_walk.py
+++ b/tempus_bench/generators/random_walk.py
@@ -1,0 +1,23 @@
+"""Generator: random_walk.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def random_walk(T=DEFAULT_T, seed=None, sigma=1.0):
+    """Driftless random walk: y_t = y_{t-1} + sigma*eps_t, y_0 = 0.
+
+    Difference-stationary (unit root).  Bayes forecast is the last observed
+    value at every horizon (martingale), with forecast variance sigma^2 h.
+    Models should neither extrapolate local drift nor revert to the
+    historical mean.
+    """
+    rng = _rng(seed)
+    return np.cumsum(sigma * rng.standard_normal(T))

--- a/tempus_bench/generators/random_walk_drift.py
+++ b/tempus_bench/generators/random_walk_drift.py
@@ -1,0 +1,28 @@
+"""Generator: random_walk_drift.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _rng
+
+
+def random_walk_drift(T=DEFAULT_T, seed=None, drift=0.08, sigma=1.0):
+    """Random walk with drift: y_t = drift + y_{t-1} + sigma*eps_t.
+
+    drift = 0.08 makes the drift identifiable from the realisation the model
+    actually sees: the sample-mean increment has s.e. sigma/sqrt(T) ~= 0.022,
+    so the drift estimate carries an expected t-statistic of ~3.6 (seed-
+    dependent in realisation), and the cumulative
+    drift (drift*T ~= 164) dominates the walk's typical excursion
+    (sigma*sqrt(T) ~= 45).  (An earlier drift of 0.02 was rejected: it was
+    statistically unidentifiable from a single path - s.e. of the estimate
+    equal to the drift itself - making the task a duplicate of random_walk.)
+    Bayes forecast: last value + drift*h.
+    """
+    rng = _rng(seed)
+    return np.cumsum(drift + sigma * rng.standard_normal(T))

--- a/tempus_bench/generators/setar.py
+++ b/tempus_bench/generators/setar.py
@@ -1,0 +1,37 @@
+"""Generator: setar.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import BURN_IN, DEFAULT_T, _rng
+
+
+def setar(T=DEFAULT_T, seed=None, phi_low=0.95, phi_high=0.4, sigma=0.5):
+    """Self-exciting threshold AR with asymmetric persistence (threshold 0):
+
+        y_t = 0.95 y_{t-1} + sigma*eps_t   if y_{t-1} <= 0,
+        y_t = 0.40 y_{t-1} + sigma*eps_t   if y_{t-1} >  0.
+
+    Both regimes mean-revert to 0 (geometrically ergodic), but negative
+    excursions decay slowly while positive ones die out almost immediately
+    - the signature sign-asymmetry of threshold models (cf. unemployment
+    dynamics).  A single linear AR fits an averaged phi and systematically
+    over-predicts persistence above the threshold and under-predicts it
+    below, so the task cleanly separates linear from nonlinear models.
+    (An earlier design with opposite-signed regime intercepts was rejected:
+    it produced a near period-2 flip-flop that a linear AR with a negative
+    lag-1 coefficient imitates well.)
+    """
+    rng = _rng(seed)
+    n = T + BURN_IN
+    y = np.zeros(n)
+    eps = rng.standard_normal(n) * sigma
+    for t in range(1, n):
+        phi = phi_low if y[t - 1] <= 0.0 else phi_high
+        y[t] = phi * y[t - 1] + eps[t]
+    return y[BURN_IN:]

--- a/tempus_bench/generators/sinusoidal_seasonal.py
+++ b/tempus_bench/generators/sinusoidal_seasonal.py
@@ -1,0 +1,22 @@
+"""Generator: sinusoidal_seasonal.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def sinusoidal_seasonal(T=DEFAULT_T, seed=None, amp=10.0, period=PERIOD,
+                        sigma=1.0):
+    """Pure stationary cycle: y_t = amp*sin(2 pi t/period) + sigma*eps_t.
+
+    The reference seasonality task: high SNR, fixed period, sinusoidal
+    shape.  Bayes forecast is the sinusoid itself (MSE sigma^2).
+    """
+    rng = _rng(seed)
+    return amp * np.sin(2 * np.pi * _t(T) / period) + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/skellam_integer.py
+++ b/tempus_bench/generators/skellam_integer.py
@@ -1,0 +1,30 @@
+"""Generator: skellam_integer.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def skellam_integer(T=DEFAULT_T, seed=None):
+    """Signed integers (difference of two seasonal Poisson flows):
+
+        y_t = N1_t - N2_t,  N1 ~ Poi(exp(1.2 + 0.8 s_t)),
+                            N2 ~ Poi(exp(1.2 - 0.8 s_t)),
+        s_t = sin(2 pi t/24).
+
+    Anti-phase intensities give a seasonal signed count with mean
+    2*exp(1.2)*sinh(0.8 s_t) swinging roughly +/-5.9 - integer-valued but
+    crossing zero, covering the 'count (negative and positive)' target
+    type that pure Poisson tasks cannot.
+    """
+    rng = _rng(seed)
+    s = np.sin(2 * np.pi * _t(T) / PERIOD)
+    n1 = rng.poisson(np.exp(1.2 + 0.8 * s))
+    n2 = rng.poisson(np.exp(1.2 - 0.8 * s))
+    return (n1 - n2).astype(float)

--- a/tempus_bench/generators/skewed_noise.py
+++ b/tempus_bench/generators/skewed_noise.py
@@ -1,0 +1,28 @@
+"""Generator: skewed_noise.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng
+
+
+def skewed_noise(T=DEFAULT_T, seed=None, s=0.8):
+    """Right-skewed innovations (centred, unit-variance log-normal):
+
+        e_t = (LN(0, s^2) - exp(s^2/2)) / sqrt((exp(s^2)-1) exp(s^2)),
+        y_t = 10 sin(2 pi t/24) + e_t.
+
+    Mean-zero but skew ~3.7: the median lies below the mean, so a model
+    trained toward the median (MAE-style) biases low on the mean and vice
+    versa.  Separates mean- from median-calibrated forecasters.
+    """
+    rng = _rng(seed)
+    raw = rng.lognormal(mean=0.0, sigma=s, size=T)
+    m = np.exp(s**2 / 2.0)
+    sd = np.sqrt((np.exp(s**2) - 1.0) * np.exp(s**2))
+    return _base_signal(T) + (raw - m) / sd

--- a/tempus_bench/generators/trend_seasonal_additive.py
+++ b/tempus_bench/generators/trend_seasonal_additive.py
@@ -1,0 +1,26 @@
+"""Generator: trend_seasonal_additive.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def trend_seasonal_additive(T=DEFAULT_T, seed=None, sigma=1.0):
+    """Non-stationary cyclical, additive composition:
+
+        y_t = 10 + 15*(t/T) + 8 sin(2 pi t/24) + sigma*eps_t.
+
+    Seasonal amplitude is constant while the level rises - the additive
+    benchmark, and simultaneously the homoskedastic reference case for the
+    noise category (constant conditional variance sigma^2).
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    return 10.0 + 15.0 * (t / T) + 8.0 * np.sin(2 * np.pi * t / PERIOD) \
+        + sigma * rng.standard_normal(T)

--- a/tempus_bench/generators/trend_seasonal_multiplicative.py
+++ b/tempus_bench/generators/trend_seasonal_multiplicative.py
@@ -1,0 +1,29 @@
+"""Generator: trend_seasonal_multiplicative.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def trend_seasonal_multiplicative(T=DEFAULT_T, seed=None, sigma_rel=0.05):
+    """Non-stationary cyclical, multiplicative composition:
+
+        y_t = trend_t * s_t * (1 + sigma_rel*eps_t),
+        trend_t = 10*(1 + t/T),   s_t = 1 + 0.4 sin(2 pi t/24).
+
+    Both the seasonal swing and the noise sd scale with the level (the
+    series is strictly positive).  The contrast with the additive task
+    isolates whether a model infers the composition type; it is also an
+    intrinsically level-heteroskedastic noise task.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    trend = 10.0 * (1.0 + t / T)
+    s = 1.0 + 0.4 * np.sin(2 * np.pi * t / PERIOD)
+    return trend * s * (1.0 + sigma_rel * rng.standard_normal(T))

--- a/tempus_bench/generators/variance_shift.py
+++ b/tempus_bench/generators/variance_shift.py
@@ -1,0 +1,25 @@
+"""Generator: variance_shift.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, _base_signal, _rng, _t
+
+
+def variance_shift(T=DEFAULT_T, seed=None, frac_break=0.6, sigma1=1.0,
+                   sigma2=2.5):
+    """One-off variance break: sigma jumps 1.0 -> 2.5 at 0.6T on the
+    reference sinusoid (conditional mean unchanged).
+
+    Point-forecast difficulty is unchanged; predictive-interval width must
+    change.  Complements level_shift by breaking the second moment only.
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    sig = np.where(t < frac_break * T, sigma1, sigma2)
+    return _base_signal(T) + sig * rng.standard_normal(T)

--- a/tempus_bench/generators/zero_inflated_continuous.py
+++ b/tempus_bench/generators/zero_inflated_continuous.py
@@ -1,0 +1,33 @@
+"""Generator: zero_inflated_continuous.
+
+See eval-synthetic-dataset/synthetic_tasks.md for the design rationale
+and the full data-generating process.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import DEFAULT_T, PERIOD, _rng, _t
+
+
+def zero_inflated_continuous(T=DEFAULT_T, seed=None):
+    """Zero-inflated *continuous* series (precipitation analogue):
+
+        p_t = sigmoid(-0.8 + 1.2 sin(2 pi t/24))  (occurrence prob ~0.12-0.6),
+        a_t ~ LogNormal(0.8, 0.5)                 (positive continuous amount),
+        y_t = 1{u_t < p_t} * a_t.
+
+    A mixed discrete-continuous marginal: an atom at exactly 0 plus a
+    right-skewed density on (0, inf), with seasonally varying occurrence
+    odds.  Unlike the count-valued intermittent tasks, the nonzero part is
+    continuous, so quantization tricks do not apply; predictive
+    distributions must represent both the zero mass and the continuous
+    tail (as in precipitation forecasting).
+    """
+    rng = _rng(seed)
+    t = _t(T)
+    p = 1.0 / (1.0 + np.exp(-(-0.8 + 1.2 * np.sin(2 * np.pi * t / PERIOD))))
+    occ = rng.random(T) < p
+    amount = rng.lognormal(mean=0.8, sigma=0.5, size=T)
+    return (occ * amount).astype(float)

--- a/tempus_bench/pipeline/data_loader.py
+++ b/tempus_bench/pipeline/data_loader.py
@@ -27,12 +27,14 @@ Example:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Final, List, Set
 
 import numpy as np
 import polars as pl
 
+from .. import generators
 from ..utils.configs import EvaluationConfig, TaskConfig
 from .data_types import Dataset
 from .preprocessor import Preprocessor
@@ -125,12 +127,15 @@ class DataLoader:
     artificial column naming for maximum flexibility.
     """
 
+    _SYNTHETIC_EPOCH: Final[datetime] = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
     def __init__(
         self,
         task_config: TaskConfig,
         evaluation_config: EvaluationConfig,
         *,
         force_no_normalize: bool = False,
+        base_seed: int | None = None,
     ):
         """
         Initialize the loader for a specific task and evaluation configuration.
@@ -142,10 +147,19 @@ class DataLoader:
                 benchmark settings for evaluation.
             force_no_normalize: If True, skip ``StandardScaler`` on targets (same missing-value
                 handling as training). Used to export UI display series in raw units.
+            base_seed: Base seed for generator tasks. The per-generator seed is derived
+                from it and the generator's id. Ignored by application tasks.
         """
         self.task_config = task_config
         self.evaluation_config = evaluation_config
         self._force_no_normalize = force_no_normalize
+        self._base_seed = base_seed
+
+        if self.task_config.is_synthetic():
+            self.dataset_path = None
+            self._load_generated_dataset()
+            return
+
         from tempus_bench.utils.paths import get_dataset_path
 
         self.dataset_path = get_dataset_path(
@@ -154,6 +168,121 @@ class DataLoader:
         )
 
         self._load_dataset()
+
+    def _synthetic_timestamps(self, num_steps: int) -> List[str]:
+        """Regular hourly ISO 8601 index; generator series are index-based.
+
+        Calendar frequency is an application-taskbed axis, so the stamps exist only
+        to satisfy the shared timestamp handling downstream.
+        """
+        return [
+            (self._SYNTHETIC_EPOCH + timedelta(hours=step)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            for step in range(num_steps)
+        ]
+
+    def _load_generated_dataset(self) -> None:
+        """
+        Build a Dataset by running a generator instead of reading a CSV.
+
+        Column order follows the generator docstrings: univariate generators return
+        ``(T,)``; multivariate and covariate generators return ``(T, m)`` with the
+        targets first, then the covariates.
+
+        Raises:
+            KeyError: If the task names a generator that is not in the registry.
+            ValueError: If the generator's column count disagrees with the task's
+                declared target and covariate names.
+        """
+        name = self.task_config.dataset_name
+        base_seed = 0 if self._base_seed is None else self._base_seed
+        seed = generators.resolve_seed(base_seed, name)
+
+        raw = np.asarray(
+            generators.generate(
+                name,
+                T=self.task_config.series_length,
+                seed=seed,
+                **self.task_config.generator_params,
+            ),
+            dtype=float,
+        )
+        if raw.ndim == 1:
+            raw = raw[:, None]
+
+        target_names = self.task_config.effective_targets()
+        covariate_names = self.task_config.effective_covariates()
+        expected = len(target_names) + len(covariate_names)
+        if raw.shape[1] != expected:
+            raise ValueError(
+                f"Generator {name!r} returned {raw.shape[1]} column(s) but task "
+                f"{self.task_config.task_name!r} declares {len(target_names)} target(s) "
+                f"and {len(covariate_names)} covariate(s)"
+            )
+
+        timestamps_str = self._synthetic_timestamps(raw.shape[0])
+        target_data = [raw[:, i].tolist() for i in range(len(target_names))]
+        covariate_data = [
+            raw[:, len(target_names) + i].tolist() for i in range(len(covariate_names))
+        ]
+
+        normalize = (
+            False if self._force_no_normalize else self.task_config.is_normalize()
+        )
+        handle_missing = self.task_config.handle_missing
+        preprocessor = Preprocessor(self.task_config, self.evaluation_config)
+
+        timestamps, time_start, time_freq, target, scaler = preprocessor.clean(
+            timestamps_str[0],
+            "h",
+            str(target_data),
+            normalize,
+            handle_missing,
+        )
+
+        if covariate_data:
+            _, _, _, covariate, _ = preprocessor.clean(
+                timestamps_str[0],
+                "h",
+                str(covariate_data),
+                normalize=False,
+                handle_missing=handle_missing,
+            )
+        else:
+            covariate = None
+
+        self.scaler = scaler
+
+        assert target.ndim == 2  # (num_steps, num_targets)
+        assert timestamps.ndim == 1  # (num_steps,)
+        if covariate is not None:
+            assert covariate.ndim == 2  # (num_steps, num_covariates)
+            assert covariate.shape[0] == target.shape[0]
+
+        meta = {
+            "dataset_path": None,
+            "generator_name": name,
+            "generator_seed": seed,
+            "base_seed": base_seed,
+            "time_start": time_start,
+            "time_freq": time_freq,
+            "num_targets": target.shape[1],
+            "num_covariates": covariate.shape[1] if covariate is not None else 0,
+            "task_mode": self.task_config.task_mode,
+            "target_variable_names": target_names,
+            "covariate_variable_names": covariate_names,
+            "target_variable_units": ["unitless"] * len(target_names),
+            "covariate_variable_units": ["unitless"] * len(covariate_names),
+        }
+        if scaler is not None:
+            meta["target_scaler_mean"] = scaler.mean_.tolist()
+            meta["target_scaler_scale"] = scaler.scale_.tolist()
+
+        self.dataset = Dataset(
+            timestamps=timestamps.tolist(),
+            target=target.tolist(),
+            covariate=covariate.tolist() if covariate is not None else None,
+            metadata=meta,
+        )
 
     def _load_dataset(self) -> None:
         """

--- a/tempus_bench/pipeline/hyperparameter_tuner.py
+++ b/tempus_bench/pipeline/hyperparameter_tuner.py
@@ -146,14 +146,66 @@ class HyperparameterTuner:
 
         self.model_name = job_config.model_config.model_name
         self.tuning_loss = self.evaluation_config.tuning_loss
-        from tempus_bench.utils.paths import get_dataset_path
+        if self.task_config.is_synthetic():
+            # Generator tasks have no CSV; their data is produced at load time.
+            self.dataset_file_path = None
+            self.dataset_path = Path(self.task_config.task_path)
+        else:
+            from tempus_bench.utils.paths import get_dataset_path
 
-        self.dataset_file_path = get_dataset_path(
-            self.task_config.dataset_category,
-            self.task_config.dataset_name,
-        )
-        self.dataset_path = self.dataset_file_path.parent
+            self.dataset_file_path = get_dataset_path(
+                self.task_config.dataset_category,
+                self.task_config.dataset_name,
+            )
+            self.dataset_path = self.dataset_file_path.parent
         self.visualizer = Visualizer()
+
+    @staticmethod
+    def _mean_metrics_over_windows(windows_eval_outputs: List[dict]) -> dict:
+        """Average each scalar metric across a model's rolling windows.
+
+        Artifacts (``y_true``, ``y_pred``, timestamps) are not scalars and are
+        dropped by the same filter used for the results sink.
+        """
+        per_window = [_metrics_dict_for_bq(outputs) for outputs in windows_eval_outputs]
+        names = {name for window in per_window for name in window}
+        return {
+            name: float(np.mean([w[name] for w in per_window if name in w]))
+            for name in names
+        }
+
+    @staticmethod
+    def _select_best_params(losses: dict, required_seeds: set | None = None) -> tuple:
+        """
+        Pick the hyperparameter configuration with the lowest averaged loss.
+
+        Args:
+            losses: ``{params: {base_seed: loss}}``, one loss per seed.
+            required_seeds: If given, only configurations that produced a loss for
+                every one of these seeds are eligible. A configuration that failed
+                on one seed must not win on the seeds where it survived.
+
+        Returns:
+            tuple: The winning params key.
+
+        Raises:
+            ValueError: If no configuration covers every required seed.
+        """
+        eligible = {}
+        for params, per_seed in losses.items():
+            if required_seeds is not None and not required_seeds.issubset(per_seed):
+                continue
+            values = [value for value in per_seed.values() if value is not None]
+            if not values:
+                continue
+            # Seeds weigh equally: the per-seed losses are already window means.
+            eligible[params] = float(np.mean(values))
+        if not eligible:
+            raise ValueError(
+                "no hyperparameter configuration produced a loss for every required "
+                f"seed {sorted(required_seeds or [])}"
+            )
+        return min(eligible, key=lambda key: eligible[key])
 
     def _generate_hyperparameter_grid(self) -> List[dict]:
         """
@@ -260,6 +312,21 @@ class HyperparameterTuner:
         _force_tqdm = os.environ.get("TEMPUSBENCH_FORCE_TQDM", "").strip() == "1"
         _show_hp_bar = _force_tqdm or sys.stdout.isatty()
         last_trial_error: Optional[BaseException] = None
+
+        # Generator tasks are evaluated once per base seed; application tasks have
+        # no seed dimension and run exactly as before. Models can overfit an
+        # individual seed, so with several seeds the winning hyperparameters are
+        # the ones with the lowest loss averaged across all of them.
+        base_seeds = (
+            self.evaluation_config.seed_list()
+            if self.task_config.is_synthetic()
+            else [None]
+        )
+        primary_seed = base_seeds[0]
+        multiseed = len(base_seeds) > 1
+        seed_losses: dict = {}
+        seed_metrics: dict = {}
+
         for params in tqdm(
             _grid_list,
             desc="Hyperparameter Combinations",
@@ -274,7 +341,42 @@ class HyperparameterTuner:
                     context_steps=context_steps,
                     train_steps=train_steps,
                     validate_steps=validate_steps,
+                    base_seed=primary_seed,
                 )
+
+                if multiseed:
+                    # Snapshot before the window loop below pops the artifacts.
+                    key = tuple(sorted(params.items()))
+                    primary_metrics = self._mean_metrics_over_windows(
+                        windows_eval_outputs
+                    )
+                    seed_metrics.setdefault(key, {})[primary_seed] = primary_metrics
+                    seed_losses.setdefault(key, {})[primary_seed] = primary_metrics.get(
+                        self.tuning_loss
+                    )
+
+                    for extra_seed in base_seeds[1:]:
+                        try:
+                            extra_outputs = model_executor.execute_model(
+                                hyperparameters=params,
+                                context_steps=context_steps,
+                                train_steps=train_steps,
+                                validate_steps=validate_steps,
+                                base_seed=extra_seed,
+                            )
+                        except Exception as seed_error:
+                            last_trial_error = seed_error
+                            LogManager.get_logger().error(
+                                "HyperparameterTuner",
+                                f"Error executing model {self.model_name} with params "
+                                f"{params} on seed {extra_seed}: {seed_error}",
+                            )
+                            continue
+                        extra_metrics = self._mean_metrics_over_windows(extra_outputs)
+                        seed_metrics[key][extra_seed] = extra_metrics
+                        seed_losses[key][extra_seed] = extra_metrics.get(
+                            self.tuning_loss
+                        )
 
             except Exception as e:
                 last_trial_error = e
@@ -382,6 +484,37 @@ class HyperparameterTuner:
             LogManager.get_logger().error("HyperparameterTuner", " ".join(parts))
             return {}, {}
 
+        if multiseed:
+            # Selection on the seed-averaged tuning loss, then report that
+            # configuration's metrics averaged over seeds. Configurations that
+            # failed on any seed are not eligible.
+            best_params = self._select_best_params(
+                seed_losses, required_seeds=set(base_seeds)
+            )
+            per_seed_metrics = seed_metrics[best_params]
+            avg_test_loss = {
+                metric: (
+                    float(
+                        np.mean(
+                            [
+                                metrics[metric]
+                                for metrics in per_seed_metrics.values()
+                                if metric in metrics
+                            ]
+                        )
+                    )
+                    if any(metric in metrics for metrics in per_seed_metrics.values())
+                    else float("nan")
+                )
+                for metric in evaluation_metrics  # type: ignore
+            }
+            LogManager.get_logger().info(
+                "HyperparameterTuner",
+                f"Selected {dict(best_params)} on the mean {self.tuning_loss} across "
+                f"{len(base_seeds)} seeds {base_seeds}",
+            )
+            return self._finalize(avg_test_loss, [best_params])
+
         # Aggregate test loss over windows, for each metric.
         # With 2+ windows: use hyperparams chosen on window j to score metrics on window j+1.
         # With 1 window: there is no next-window holdout — report that window's metrics directly.
@@ -407,6 +540,28 @@ class HyperparameterTuner:
             )
             for metric in evaluation_metrics  # type: ignore
         }
+
+        return self._finalize(avg_test_loss, optimal_hyperparameters)
+
+    def _finalize(
+        self, avg_test_loss: dict, optimal_hyperparameters: list
+    ) -> Tuple[dict, dict]:
+        """
+        Write the evaluations CSV row and package the return value.
+
+        Shared by the single-seed (walk-forward) and multi-seed (seed-averaged)
+        selection paths so both report results identically.
+
+        Args:
+            avg_test_loss: Metric name to averaged value for the selected configuration.
+            optimal_hyperparameters: Selected hyperparameter assignments.
+
+        Returns:
+            Tuple[dict, dict]: Evaluations and best hyperparameters, both keyed by
+                model name then dataset path.
+        """
+        all_evals: dict = {}
+        best_hyperparameters: dict = {}
 
         # Write to evaluations CSV in parent directory
         csv_filename = f"evaluations.csv"

--- a/tempus_bench/pipeline/model_executor.py
+++ b/tempus_bench/pipeline/model_executor.py
@@ -23,7 +23,11 @@ from typing import Any, Dict, Optional
 
 
 from tempus_bench.utils.envs import CondaEnvManager
-from tempus_bench.utils.paths import get_project_root, get_models_dir
+from tempus_bench.utils.paths import (
+    get_project_root,
+    get_models_dir,
+    task_dataset_filename,
+)
 from tempus_bench.utils.model_settings import (
     get_past_only_covariate_models,
     get_no_covariate_models,
@@ -182,6 +186,7 @@ class ModelExecutor:
         context_steps: int,
         train_steps: int,
         validate_steps: int,
+        base_seed: int | None = None,
     ) -> dict:
         """
         Execute a single model with specific hyperparameters on dataset windows.
@@ -235,12 +240,13 @@ class ModelExecutor:
 
             # Add absolute path to task dataset so subprocess finds it regardless of cwd
             task_name = self.job_config["task_config"]["task_name"]
+            filename = task_dataset_filename(task_name, base_seed)
             tdir = self.job_config.get("task_datasets_dir")
             if tdir:
-                task_dataset_path = str(Path(tdir) / f"{task_name}.pkl")
+                task_dataset_path = str(Path(tdir) / filename)
             else:
                 task_dataset_path = str(
-                    Path(get_project_root()) / "temp_task_datasets" / f"{task_name}.pkl"
+                    Path(get_project_root()) / "temp_task_datasets" / filename
                 )
             job_config_to_write = {
                 **self.job_config,

--- a/tempus_bench/run_benchmark.py
+++ b/tempus_bench/run_benchmark.py
@@ -45,6 +45,7 @@ _import_stage("HyperparameterTuner")
 from tempus_bench.pipeline.hyperparameter_tuner import HyperparameterTuner
 _import_stage("DataLoader")
 from tempus_bench.pipeline.data_loader import DataLoader
+from tempus_bench.utils.paths import task_dataset_filename
 _import_stage("imports_done")
 
 
@@ -151,15 +152,28 @@ class BenchmarkRunner:
         )
         self.temp_task_datasets_dir = Path(self._task_datasets_tmp.name)
 
+        seeds = self.manager.evaluation_config.seed_list()
+
         for task_name, task_config in self.manager.task_configs.items():
 
-            task_path = self.temp_task_datasets_dir / f"{task_name}.pkl"
-            data_loader = DataLoader(task_config, self.manager.evaluation_config)
+            # Application tasks have no seed; generator tasks get one dataset per
+            # base seed so every model in the run sees identical data per seed.
+            base_seeds = seeds if task_config.is_synthetic() else [None]
 
-            dataset = data_loader.dataset
+            for base_seed in base_seeds:
+                task_path = self.temp_task_datasets_dir / task_dataset_filename(
+                    task_name, base_seed
+                )
+                data_loader = DataLoader(
+                    task_config,
+                    self.manager.evaluation_config,
+                    base_seed=base_seed,
+                )
 
-            with open(task_path, "wb") as f:
-                pickle.dump(dataset, f)
+                dataset = data_loader.dataset
+
+                with open(task_path, "wb") as f:
+                    pickle.dump(dataset, f)
 
         return self
 

--- a/tempus_bench/utils/configs.py
+++ b/tempus_bench/utils/configs.py
@@ -8,7 +8,7 @@ validation, type checking, and documentation of the benchmarking pipeline.
 import yaml
 
 from pathlib import Path
-from typing import Any, Dict, Final, List, Literal, Optional
+from typing import Any, Dict, Final, List, Literal, Optional, Union
 
 # Upper bound for ``evaluation.max_windows`` in YAML/programmatic configs (rolling-window count).
 MAX_EVALUATION_WINDOWS: Final[int] = 5
@@ -118,6 +118,29 @@ class EvaluationConfig(BaseModel):
         default="mean",
         description="Statistic to use for converting stochastic predictions to point forecasts",
     )
+    seeds: Union[int, List[int]] = Field(
+        default=0,
+        description=(
+            "Base seed, or a list of base seeds to evaluate and average over. "
+            "Generator tasks derive their per-generator seed from these; application "
+            "tasks ignore them. Each extra seed multiplies run time."
+        ),
+    )
+
+    @field_validator("seeds")
+    @classmethod
+    def _validate_seeds(cls, value):
+        if isinstance(value, int):
+            return value
+        if len(value) == 0:
+            raise ValueError("seeds must contain at least one seed")
+        if len(set(value)) != len(value):
+            raise ValueError("seeds must not contain duplicate values")
+        return value
+
+    def seed_list(self) -> List[int]:
+        """Base seeds as a list, whether one or many were configured."""
+        return [self.seeds] if isinstance(self.seeds, int) else list(self.seeds)
 
 
 class ModelConfig:
@@ -214,9 +237,12 @@ class TaskConfig(BaseModel):
         default="standard",
         description="Normalization applied to targets during preprocessing",
     )
-    file_name: str = Field(
-        ...,
-        description="Dataset CSV file name ({dataset_name}.csv); kept for legacy call sites",
+    file_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Dataset CSV file name ({dataset_name}.csv); kept for legacy call sites. "
+            "None for generator tasks, whose data has no file."
+        ),
     )
     task_mode: Literal["univariate", "multivariate", "covariate"] = Field(
         ..., description="Evaluation mode for this logical task"
@@ -228,10 +254,48 @@ class TaskConfig(BaseModel):
         default_factory=list,
         description="Active covariate variate names for this logical task/mode",
     )
+    target_type: Optional[str] = Field(
+        default=None,
+        description=(
+            "Support of the marginal, e.g. continuous_real, continuous_positive, "
+            "count_positive, binary. Generator tasks only."
+        ),
+    )
+    series_length: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="T passed to the generator (generator tasks only)",
+    )
+    generator_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra keyword arguments forwarded to the generator",
+    )
+
+    @model_validator(mode="after")
+    def _check_catalog_requirements(self):
+        """Each catalog has its own required fields; neither borrows the other's."""
+        if self.is_synthetic():
+            if self.file_name:
+                raise ValueError(
+                    f"{self.task_name}: generator tasks must not set file_name; "
+                    "their data is generated, not downloaded"
+                )
+        elif not self.file_name:
+            raise ValueError(f"{self.task_name}: application tasks require file_name")
+        return self
+
+    def is_synthetic(self) -> bool:
+        """True when this task's data comes from a generator rather than a file."""
+        return self.task_catalog == "synthetic"
 
     @property
     def dataset(self) -> DatasetConfig:
         """Legacy adapter exposing nested dataset fields."""
+        if self.is_synthetic():
+            raise AttributeError(
+                f"{self.task_name}: generator tasks have no dataset file; "
+                "use dataset_name to look up the generator"
+            )
         return DatasetConfig(
             handle_missing=self.handle_missing,
             file_name=self.file_name,

--- a/tempus_bench/utils/paths.py
+++ b/tempus_bench/utils/paths.py
@@ -289,3 +289,22 @@ def get_available_metrics() -> list[Path]:
         ):
             metric_files.append(file_path.resolve())
     return metric_files
+
+
+def task_dataset_filename(task_name: str, base_seed: int | None) -> str:
+    """
+    Pickle filename for a prepared task dataset.
+
+    Application tasks have no seed and keep the historical unsuffixed name, so
+    their cache paths are unchanged. Generator tasks get one pickle per base seed.
+
+    Args:
+        task_name (str): Logical task name.
+        base_seed (int | None): Base seed for generator tasks, None for application tasks.
+
+    Returns:
+        str: The pickle filename.
+    """
+    if base_seed is None:
+        return f"{task_name}.pkl"
+    return f"{task_name}__seed{base_seed}.pkl"

--- a/tempus_bench/utils/task_yaml_loader.py
+++ b/tempus_bench/utils/task_yaml_loader.py
@@ -45,22 +45,30 @@ def build_task_config_from_raw(raw: dict[str, Any]) -> TaskConfig:
     covariates = list(raw.get("covariate_variable_names") or [])
     task_mode = infer_task_mode(targets, covariates)
     logical_path = f"{dataset_category}/{task_name}"
+    task_catalog = raw.get("task_catalog") or "application"
+
+    # Generator tasks produce their data at load time, so there is no CSV to name.
+    # dataset_name is the generator key in tempus_bench/generators/metadata.json.
+    is_synthetic = task_catalog == "synthetic"
 
     return TaskConfig(
         task_name=task_name,
         task_path=logical_path,
         task_description=raw.get("task_description") or "",
-        task_catalog=raw.get("task_catalog") or "application",
+        task_catalog=task_catalog,
         dataset_category=dataset_category,
         dataset_name=dataset_name,
         context_window=raw["context_window"],
         forecast_horizon=raw["forecast_horizon"],
         handle_missing=raw.get("handle_missing", "interpolate"),
         normalization_method=raw.get("normalization_method", "standard"),
-        file_name=f"{dataset_name}.csv",
+        file_name=None if is_synthetic else f"{dataset_name}.csv",
         task_mode=task_mode,
         target_variable_names=targets,
         covariate_variable_names=covariates,
+        target_type=raw.get("target_type"),
+        series_length=raw.get("series_length"),
+        generator_params=raw.get("generator_params") or {},
     )
 
 

--- a/tests/unit/test_generators_registry.py
+++ b/tests/unit/test_generators_registry.py
@@ -1,0 +1,48 @@
+"""Registry integrity for the data generators."""
+
+import numpy as np
+import pytest
+
+from tempus_bench import generators
+
+
+def test_metadata_has_54_generators_with_unique_ids():
+    meta = generators.load_metadata()
+    assert len(meta) == 54
+    ids = [entry["generator_id"] for entry in meta.values()]
+    assert sorted(ids) == list(range(1, 55))
+
+
+@pytest.mark.parametrize("name", sorted(generators.load_metadata()))
+def test_every_generator_imports_and_returns_expected_shape(name):
+    meta = generators.load_metadata()[name]
+    out = generators.generate(name, T=256, seed=0)
+    assert isinstance(out, np.ndarray)
+    assert np.all(np.isfinite(out))
+    if meta["variate"] == "univariate":
+        assert out.shape == (256,)
+    else:
+        assert out.ndim == 2 and out.shape[0] == 256
+
+
+def test_same_seed_reproduces_same_series():
+    a = generators.generate("random_walk", T=128, seed=7)
+    b = generators.generate("random_walk", T=128, seed=7)
+    c = generators.generate("random_walk", T=128, seed=8)
+    assert np.array_equal(a, b)
+    assert not np.array_equal(a, c)
+
+
+def test_default_series_length_comes_from_metadata():
+    out = generators.generate("linear_trend", seed=0)
+    assert out.shape == (generators.load_metadata()["linear_trend"]["default_series_length"],)
+
+
+def test_unknown_generator_raises_keyerror_naming_the_generator():
+    with pytest.raises(KeyError, match="no_such_generator"):
+        generators.generate("no_such_generator")
+
+
+def test_every_entry_declares_a_primary_category_within_its_categories():
+    for name, entry in generators.load_metadata().items():
+        assert entry["primary_category"] == entry["categories"][0], name

--- a/tests/unit/test_multiseed_dataset_preparation.py
+++ b/tests/unit/test_multiseed_dataset_preparation.py
@@ -1,0 +1,101 @@
+"""End-to-end check of the per-seed dataset preparation loop.
+
+Mirrors what ``BenchmarkRunner.__enter__`` does, without spawning model
+subprocesses: every configured base seed must yield its own pickled Dataset, and
+the pickles must differ from each other but be reproducible.
+"""
+
+import pickle
+import tempfile
+
+import numpy as np
+import pytest
+
+from tempus_bench.pipeline.data_loader import DataLoader
+from tempus_bench.utils.configs import EvaluationConfig
+from tempus_bench.utils.log_manager import LogManager
+from tempus_bench.utils.paths import task_dataset_filename
+from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+
+
+@pytest.fixture(autouse=True)
+def _log_manager():
+    LogManager.log_manager = None
+    with tempfile.TemporaryDirectory() as d:
+        lm = LogManager(
+            logs_path=d,
+            console_logging=False,
+            file_logging=False,
+            tensorboard_logging=False,
+        )
+        yield lm
+        try:
+            lm.close()
+        except Exception:
+            pass
+        LogManager.log_manager = None
+
+
+def _prepare(task_configs, evaluation_config, out_dir):
+    """The dataset preparation loop from BenchmarkRunner.__enter__."""
+    seeds = evaluation_config.seed_list()
+    written = []
+    for task_config in task_configs:
+        base_seeds = seeds if task_config.is_synthetic() else [None]
+        for base_seed in base_seeds:
+            path = out_dir / task_dataset_filename(task_config.task_name, base_seed)
+            loader = DataLoader(task_config, evaluation_config, base_seed=base_seed)
+            with open(path, "wb") as handle:
+                pickle.dump(loader.dataset, handle)
+            written.append(path)
+    return written
+
+
+def test_each_seed_produces_its_own_dataset(tmp_path):
+    configs = load_synthetic_task_configs("Synthetic Tasks/Covariate")
+    evaluation = EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=[0, 1, 2])
+
+    written = _prepare(configs, evaluation, tmp_path)
+
+    assert len(written) == len(configs) * 3
+    assert all(path.is_file() for path in written)
+
+
+def test_datasets_differ_across_seeds_but_repeat_within_a_seed(tmp_path):
+    configs = [c for c in load_synthetic_task_configs("Synthetic Tasks/Covariate")][:1]
+    evaluation = EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=[0, 1])
+
+    _prepare(configs, evaluation, tmp_path)
+    first = tmp_path / task_dataset_filename(configs[0].task_name, 0)
+    second = tmp_path / task_dataset_filename(configs[0].task_name, 1)
+
+    with open(first, "rb") as handle:
+        a = pickle.load(handle)
+    with open(second, "rb") as handle:
+        b = pickle.load(handle)
+
+    assert not np.array_equal(np.array(a.target), np.array(b.target))
+    assert a.metadata["base_seed"] == 0
+    assert b.metadata["base_seed"] == 1
+
+    # Re-preparing seed 0 reproduces it exactly.
+    again = tmp_path / "again"
+    again.mkdir()
+    _prepare(
+        configs,
+        EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=0),
+        again,
+    )
+    with open(again / task_dataset_filename(configs[0].task_name, 0), "rb") as handle:
+        repeat = pickle.load(handle)
+    assert np.array_equal(np.array(a.target), np.array(repeat.target))
+
+
+def test_the_whole_taskbed_prepares_under_a_single_seed(tmp_path):
+    configs = load_synthetic_task_configs("Synthetic Tasks")
+    evaluation = EvaluationConfig(task_path="Synthetic Tasks", seeds=0)
+
+    written = _prepare(configs, evaluation, tmp_path)
+
+    assert len(written) == 54
+    assert len({path.name for path in written}) == 54

--- a/tests/unit/test_multiseed_dataset_preparation.py
+++ b/tests/unit/test_multiseed_dataset_preparation.py
@@ -15,7 +15,31 @@ from tempus_bench.pipeline.data_loader import DataLoader
 from tempus_bench.utils.configs import EvaluationConfig
 from tempus_bench.utils.log_manager import LogManager
 from tempus_bench.utils.paths import task_dataset_filename
-from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+import yaml
+
+from tempus_bench.utils.paths import get_project_root
+from tempus_bench.utils.task_yaml_loader import build_task_config_from_raw
+
+
+CATALOG = get_project_root() / "Tasks" / "Synthetic Tasks"
+
+
+def _catalog_configs(category_file: str | None = None):
+    """Load generator task configs straight from the synthetic catalog.
+
+    Reads the files directly rather than through the global catalog loader, so
+    these tests cover the generator taskbed alone.
+    """
+    paths = (
+        [CATALOG / category_file] if category_file else sorted(CATALOG.glob("*.yaml"))
+    )
+    configs = []
+    for path in paths:
+        with path.open(encoding="utf-8") as handle:
+            for doc in yaml.safe_load_all(handle):
+                if doc and "task" in doc:
+                    configs.append(build_task_config_from_raw(doc["task"]))
+    return configs
 
 
 @pytest.fixture(autouse=True)
@@ -52,8 +76,8 @@ def _prepare(task_configs, evaluation_config, out_dir):
 
 
 def test_each_seed_produces_its_own_dataset(tmp_path):
-    configs = load_synthetic_task_configs("Synthetic Tasks/Covariate")
-    evaluation = EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=[0, 1, 2])
+    configs = _catalog_configs("Covariate.yaml")
+    evaluation = EvaluationConfig(task_path="covariate/*", seeds=[0, 1, 2])
 
     written = _prepare(configs, evaluation, tmp_path)
 
@@ -62,8 +86,8 @@ def test_each_seed_produces_its_own_dataset(tmp_path):
 
 
 def test_datasets_differ_across_seeds_but_repeat_within_a_seed(tmp_path):
-    configs = [c for c in load_synthetic_task_configs("Synthetic Tasks/Covariate")][:1]
-    evaluation = EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=[0, 1])
+    configs = [c for c in _catalog_configs("Covariate.yaml")][:1]
+    evaluation = EvaluationConfig(task_path="covariate/*", seeds=[0, 1])
 
     _prepare(configs, evaluation, tmp_path)
     first = tmp_path / task_dataset_filename(configs[0].task_name, 0)
@@ -83,7 +107,7 @@ def test_datasets_differ_across_seeds_but_repeat_within_a_seed(tmp_path):
     again.mkdir()
     _prepare(
         configs,
-        EvaluationConfig(task_path="Synthetic Tasks/Covariate", seeds=0),
+        EvaluationConfig(task_path="covariate/*", seeds=0),
         again,
     )
     with open(again / task_dataset_filename(configs[0].task_name, 0), "rb") as handle:
@@ -92,8 +116,8 @@ def test_datasets_differ_across_seeds_but_repeat_within_a_seed(tmp_path):
 
 
 def test_the_whole_taskbed_prepares_under_a_single_seed(tmp_path):
-    configs = load_synthetic_task_configs("Synthetic Tasks")
-    evaluation = EvaluationConfig(task_path="Synthetic Tasks", seeds=0)
+    configs = _catalog_configs()
+    evaluation = EvaluationConfig(task_path="*", seeds=0)
 
     written = _prepare(configs, evaluation, tmp_path)
 

--- a/tests/unit/test_multiseed_selection.py
+++ b/tests/unit/test_multiseed_selection.py
@@ -1,0 +1,55 @@
+"""Seed-averaged hyperparameter selection."""
+
+import numpy as np
+import pytest
+
+from tempus_bench.pipeline.hyperparameter_tuner import HyperparameterTuner
+
+A = (("alpha", 0.1),)
+B = (("alpha", 0.5),)
+
+
+def test_selects_the_config_with_the_lowest_mean_across_seeds():
+    # A wins on seed 0 but loses badly on seed 1; B is steadier and wins on average.
+    losses = {A: {0: 1.0, 1: 9.0}, B: {0: 4.0, 1: 4.0}}
+    assert HyperparameterTuner._select_best_params(losses) == B
+
+
+def test_a_single_seed_reduces_to_that_seeds_loss():
+    losses = {A: {0: 1.0}, B: {0: 2.5}}
+    assert HyperparameterTuner._select_best_params(losses) == A
+
+
+def test_configs_missing_a_seed_are_not_selectable():
+    # A has the lower loss where it ran, but it failed on seed 1 entirely.
+    losses = {A: {0: 0.1}, B: {0: 5.0, 1: 5.0}}
+    assert HyperparameterTuner._select_best_params(losses, required_seeds={0, 1}) == B
+
+
+def test_raises_when_no_config_covers_every_seed():
+    with pytest.raises(ValueError, match="no hyperparameter configuration"):
+        HyperparameterTuner._select_best_params({A: {0: 1.0}}, required_seeds={0, 1})
+
+
+def test_none_losses_are_ignored():
+    losses = {A: {0: None, 1: None}, B: {0: 3.0, 1: 3.0}}
+    assert HyperparameterTuner._select_best_params(losses) == B
+
+
+def test_mean_metrics_averages_scalars_and_drops_artifacts():
+    windows = [
+        {"mae": 1.0, "rmse": 2.0, "y_true": [1, 2, 3], "y_pred": [1, 2, 3]},
+        {"mae": 3.0, "rmse": 4.0, "y_true": [4, 5, 6], "y_pred": [4, 5, 6]},
+    ]
+    means = HyperparameterTuner._mean_metrics_over_windows(windows)
+    assert means == {"mae": 2.0, "rmse": 3.0}
+
+
+def test_mean_metrics_handles_numpy_scalars():
+    windows = [{"mae": np.float64(1.0)}, {"mae": np.float64(3.0)}]
+    assert HyperparameterTuner._mean_metrics_over_windows(windows) == {"mae": 2.0}
+
+
+def test_mean_metrics_drops_non_finite_values():
+    windows = [{"mae": 1.0}, {"mae": float("nan")}]
+    assert HyperparameterTuner._mean_metrics_over_windows(windows) == {"mae": 1.0}

--- a/tests/unit/test_seed_list_config.py
+++ b/tests/unit/test_seed_list_config.py
@@ -7,25 +7,25 @@ from tempus_bench.utils.configs import EvaluationConfig
 
 
 def test_single_int_seed_becomes_a_one_element_list():
-    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=42)
+    cfg = EvaluationConfig(task_path="trend/*", seeds=42)
     assert cfg.seed_list() == [42]
 
 
 def test_list_of_seeds_is_preserved_in_order():
-    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[42, 43, 44])
+    cfg = EvaluationConfig(task_path="trend/*", seeds=[42, 43, 44])
     assert cfg.seed_list() == [42, 43, 44]
 
 
 def test_default_is_a_single_seed():
-    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend")
+    cfg = EvaluationConfig(task_path="trend/*")
     assert cfg.seed_list() == [0]
 
 
 def test_empty_seed_list_is_rejected():
     with pytest.raises(ValidationError, match="at least one seed"):
-        EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[])
+        EvaluationConfig(task_path="trend/*", seeds=[])
 
 
 def test_duplicate_seeds_are_rejected():
     with pytest.raises(ValidationError, match="duplicate"):
-        EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[7, 7])
+        EvaluationConfig(task_path="trend/*", seeds=[7, 7])

--- a/tests/unit/test_seed_list_config.py
+++ b/tests/unit/test_seed_list_config.py
@@ -1,0 +1,31 @@
+"""Seed configuration on EvaluationConfig."""
+
+import pytest
+from pydantic import ValidationError
+
+from tempus_bench.utils.configs import EvaluationConfig
+
+
+def test_single_int_seed_becomes_a_one_element_list():
+    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=42)
+    assert cfg.seed_list() == [42]
+
+
+def test_list_of_seeds_is_preserved_in_order():
+    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[42, 43, 44])
+    assert cfg.seed_list() == [42, 43, 44]
+
+
+def test_default_is_a_single_seed():
+    cfg = EvaluationConfig(task_path="Synthetic Tasks/Trend")
+    assert cfg.seed_list() == [0]
+
+
+def test_empty_seed_list_is_rejected():
+    with pytest.raises(ValidationError, match="at least one seed"):
+        EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[])
+
+
+def test_duplicate_seeds_are_rejected():
+    with pytest.raises(ValidationError, match="duplicate"):
+        EvaluationConfig(task_path="Synthetic Tasks/Trend", seeds=[7, 7])

--- a/tests/unit/test_seed_resolution.py
+++ b/tests/unit/test_seed_resolution.py
@@ -1,0 +1,38 @@
+"""Per-generator seed derivation."""
+
+import pytest
+
+from tempus_bench import generators
+
+
+def test_seed_is_deterministic():
+    assert generators.resolve_seed(42, "random_walk") == generators.resolve_seed(
+        42, "random_walk"
+    )
+
+
+def test_generators_differ_under_the_same_base_seed():
+    names = sorted(generators.load_metadata())
+    seeds = [generators.resolve_seed(42, name) for name in names]
+    assert len(set(seeds)) == len(names)
+
+
+def test_no_collisions_across_base_seeds():
+    names = sorted(generators.load_metadata())
+    seen = set()
+    for base in range(20):
+        for name in names:
+            seed = generators.resolve_seed(base, name)
+            assert seed not in seen, f"collision at base={base} name={name}"
+            seen.add(seed)
+
+
+def test_seed_is_base_times_stride_plus_generator_id():
+    entry = generators.load_metadata()["random_walk"]
+    expected = 3 * generators.SEED_STRIDE + entry["generator_id"]
+    assert generators.resolve_seed(3, "random_walk") == expected
+
+
+def test_unknown_generator_raises():
+    with pytest.raises(KeyError, match="no_such_generator"):
+        generators.resolve_seed(0, "no_such_generator")

--- a/tests/unit/test_synthetic_data_loader.py
+++ b/tests/unit/test_synthetic_data_loader.py
@@ -1,0 +1,106 @@
+"""DataLoader building datasets from generators instead of CSV files."""
+
+import tempfile
+
+import numpy as np
+import pytest
+
+from tempus_bench.pipeline.data_loader import DataLoader
+from tempus_bench.utils.configs import EvaluationConfig, TaskConfig
+from tempus_bench.utils.log_manager import LogManager
+
+
+@pytest.fixture(autouse=True)
+def _log_manager():
+    """Preprocessor logs through the LogManager singleton."""
+    LogManager.log_manager = None
+    with tempfile.TemporaryDirectory() as d:
+        lm = LogManager(
+            logs_path=d,
+            console_logging=False,
+            file_logging=False,
+            tensorboard_logging=False,
+        )
+        yield lm
+        try:
+            lm.close()
+        except Exception:
+            pass
+        LogManager.log_manager = None
+
+
+def _task(name="random_walk", mode="univariate", targets=("y",), covariates=()):
+    return TaskConfig(
+        task_name=f"Test {name}",
+        task_path="/nonexistent",
+        context_window=64,
+        forecast_horizon=16,
+        handle_missing="interpolate",
+        normalization_method="none",
+        task_mode=mode,
+        task_catalog="synthetic",
+        dataset_category="trend",
+        dataset_name=name,
+        target_type="continuous_real",
+        series_length=256,
+        target_variable_names=list(targets),
+        covariate_variable_names=list(covariates),
+    )
+
+
+def _evaluation():
+    return EvaluationConfig(task_path="Synthetic Tasks/Trend")
+
+
+def test_generates_dataset_without_touching_disk():
+    loader = DataLoader(_task(), _evaluation(), base_seed=11)
+    dataset = loader.dataset
+
+    assert len(dataset.target) == 256
+    assert len(dataset.target[0]) == 1
+    assert dataset.covariate is None
+    assert dataset.metadata["num_targets"] == 1
+    assert dataset.metadata["target_variable_units"] == ["unitless"]
+    assert dataset.metadata["time_freq"] == "h"
+    assert dataset.metadata["generator_name"] == "random_walk"
+
+
+def test_same_base_seed_reproduces_the_series():
+    a = DataLoader(_task(), _evaluation(), base_seed=11).dataset.target
+    b = DataLoader(_task(), _evaluation(), base_seed=11).dataset.target
+    c = DataLoader(_task(), _evaluation(), base_seed=12).dataset.target
+    assert np.array_equal(np.array(a), np.array(b))
+    assert not np.array_equal(np.array(a), np.array(c))
+
+
+def test_metadata_records_the_derived_generator_seed():
+    from tempus_bench import generators
+
+    dataset = DataLoader(_task(), _evaluation(), base_seed=5).dataset
+    assert dataset.metadata["base_seed"] == 5
+    assert dataset.metadata["generator_seed"] == generators.resolve_seed(5, "random_walk")
+
+
+def test_covariate_generator_splits_target_and_covariate_columns():
+    task = _task(
+        name="covariate_nonlinear", mode="covariate", targets=("y",), covariates=("x",)
+    )
+    dataset = DataLoader(task, _evaluation(), base_seed=3).dataset
+
+    assert dataset.metadata["num_targets"] == 1
+    assert dataset.metadata["num_covariates"] == 1
+    assert len(dataset.covariate) == 256
+
+
+def test_column_count_mismatch_is_reported():
+    # mv_var returns 2 columns; declaring 1 target and no covariates is wrong.
+    task = _task(name="mv_var", mode="multivariate", targets=("y1",))
+    with pytest.raises(ValueError, match="returned .* column"):
+        DataLoader(task, _evaluation(), base_seed=0)
+
+
+def test_multivariate_generator_maps_all_columns_to_targets():
+    task = _task(name="mv_var", mode="multivariate", targets=("y1", "y2"))
+    dataset = DataLoader(task, _evaluation(), base_seed=0).dataset
+    assert dataset.metadata["num_targets"] == 2
+    assert dataset.metadata["num_covariates"] == 0

--- a/tests/unit/test_synthetic_data_loader.py
+++ b/tests/unit/test_synthetic_data_loader.py
@@ -32,7 +32,7 @@ def _log_manager():
 def _task(name="random_walk", mode="univariate", targets=("y",), covariates=()):
     return TaskConfig(
         task_name=f"Test {name}",
-        task_path="/nonexistent",
+        task_path=f"trend/Test {name}",
         context_window=64,
         forecast_horizon=16,
         handle_missing="interpolate",
@@ -49,7 +49,7 @@ def _task(name="random_walk", mode="univariate", targets=("y",), covariates=()):
 
 
 def _evaluation():
-    return EvaluationConfig(task_path="Synthetic Tasks/Trend")
+    return EvaluationConfig(task_path="trend/*")
 
 
 def test_generates_dataset_without_touching_disk():

--- a/tests/unit/test_synthetic_task_catalog.py
+++ b/tests/unit/test_synthetic_task_catalog.py
@@ -1,0 +1,113 @@
+"""The generated Tasks/Synthetic Tasks catalog stays in step with the registry."""
+
+from pathlib import Path
+
+from tempus_bench import generators
+from tempus_bench.utils.paths import get_project_root
+from tempus_bench.utils.task_yaml_loader import load_task_configs_from_category_yaml
+
+CATALOG = Path(get_project_root()) / "Tasks" / "Synthetic Tasks"
+
+
+def _all_configs():
+    for path in sorted(CATALOG.glob("*.yaml")):
+        for config in load_task_configs_from_category_yaml(path):
+            yield path, config
+
+
+def test_there_is_one_yaml_per_category():
+    categories = {
+        category
+        for entry in generators.load_metadata().values()
+        for category in entry["categories"]
+    }
+    assert len(list(CATALOG.glob("*.yaml"))) == len(categories)
+
+
+def test_every_document_loads_and_names_a_real_generator():
+    metadata = generators.load_metadata()
+    for _, config in _all_configs():
+        assert config.is_synthetic()
+        assert config.dataset_name in metadata
+        assert config.file_name is None
+
+
+def test_every_generator_appears_in_each_of_its_categories():
+    metadata = generators.load_metadata()
+    seen: dict[str, set[str]] = {}
+    for _, config in _all_configs():
+        seen.setdefault(config.dataset_name, set()).add(config.dataset_category)
+    for name, entry in metadata.items():
+        assert seen[name] == set(entry["categories"]), name
+
+
+def test_deduping_by_generator_recovers_exactly_54_tasks():
+    names = {config.dataset_name for _, config in _all_configs()}
+    assert len(names) == 54
+
+
+def test_declared_variables_match_the_generator_output_width():
+    for _, config in _all_configs():
+        width = generators.generate(config.dataset_name, T=8, seed=0)
+        columns = 1 if width.ndim == 1 else width.shape[1]
+        declared = len(config.target_variable_names) + len(
+            config.covariate_variable_names
+        )
+        assert declared == columns, config.dataset_name
+
+
+def test_count_and_binary_targets_are_not_standardised():
+    for _, config in _all_configs():
+        if config.target_type != "continuous_real":
+            assert config.normalization_method == "none", config.dataset_name
+
+
+def test_window_exceptions_from_the_design_doc_are_applied():
+    windows = {
+        config.dataset_name: (config.context_window, config.forecast_horizon)
+        for _, config in _all_configs()
+    }
+    assert windows["multi_seasonal"][0] >= 512
+    assert windows["logistic_map"][1] <= 20
+    assert windows["mv_leadlag"][1] == 16
+
+
+def test_task_path_pattern_recognises_the_synthetic_catalog():
+    from tempus_bench.utils.task_yaml_loader import is_synthetic_task_path
+
+    assert is_synthetic_task_path("Synthetic Tasks")
+    assert is_synthetic_task_path("Synthetic Tasks/Trend")
+    assert not is_synthetic_task_path("covariate/covariate_transport_monthly")
+
+
+def test_a_single_category_pattern_loads_only_that_category():
+    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+
+    configs = load_synthetic_task_configs("Synthetic Tasks/Trend")
+    assert configs
+    assert {c.dataset_category for c in configs} == {"trend"}
+
+
+def test_whole_bed_dedupes_to_one_document_per_generator():
+    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+
+    configs = load_synthetic_task_configs("Synthetic Tasks")
+    names = [c.dataset_name for c in configs]
+    assert len(names) == len(set(names)) == 54
+
+
+def test_whole_bed_keeps_each_generator_under_its_primary_category():
+    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+
+    metadata = generators.load_metadata()
+    for config in load_synthetic_task_configs("Synthetic Tasks"):
+        assert config.dataset_category == metadata[config.dataset_name]["primary_category"]
+
+
+def test_unknown_category_is_reported():
+    import pytest
+
+    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
+
+    with pytest.raises(FileNotFoundError, match="Synthetic category file not found"):
+        load_synthetic_task_configs("Synthetic Tasks/NoSuchCategory")

--- a/tests/unit/test_synthetic_task_catalog.py
+++ b/tests/unit/test_synthetic_task_catalog.py
@@ -1,63 +1,87 @@
-"""The generated Tasks/Synthetic Tasks catalog stays in step with the registry."""
+"""The generated Tasks/Synthetic Tasks catalog stays in step with the registry.
+
+Reads the synthetic catalog directly rather than through
+``paths.load_all_task_documents``, so these tests describe the generator taskbed
+alone and do not depend on the state of the application catalog.
+"""
 
 from pathlib import Path
 
+import pytest
+import yaml
+
 from tempus_bench import generators
 from tempus_bench.utils.paths import get_project_root
-from tempus_bench.utils.task_yaml_loader import load_task_configs_from_category_yaml
+from tempus_bench.utils.task_yaml_loader import build_task_config_from_raw
 
 CATALOG = Path(get_project_root()) / "Tasks" / "Synthetic Tasks"
 
 
-def _all_configs():
+def _raw_documents():
     for path in sorted(CATALOG.glob("*.yaml")):
-        for config in load_task_configs_from_category_yaml(path):
-            yield path, config
+        with path.open(encoding="utf-8") as handle:
+            for doc in yaml.safe_load_all(handle):
+                if doc and "task" in doc:
+                    yield path, doc["task"]
 
 
-def test_there_is_one_yaml_per_category():
-    categories = {
-        category
-        for entry in generators.load_metadata().values()
-        for category in entry["categories"]
+def _configs():
+    return [build_task_config_from_raw(raw) for _, raw in _raw_documents()]
+
+
+def test_there_is_one_yaml_per_primary_category():
+    primary = {
+        entry["primary_category"] for entry in generators.load_metadata().values()
     }
-    assert len(list(CATALOG.glob("*.yaml"))) == len(categories)
+    assert len(list(CATALOG.glob("*.yaml"))) == len(primary)
 
 
-def test_every_document_loads_and_names_a_real_generator():
+def test_every_generator_appears_exactly_once():
+    names = [config.dataset_name for config in _configs()]
+    assert len(names) == 54
+    assert len(set(names)) == 54
+
+
+def test_task_names_are_unique_so_the_catalog_loader_accepts_them():
+    names = [config.task_name for config in _configs()]
+    assert len(set(names)) == len(names)
+
+
+def test_every_document_names_a_real_generator_and_carries_no_file():
     metadata = generators.load_metadata()
-    for _, config in _all_configs():
+    for config in _configs():
         assert config.is_synthetic()
         assert config.dataset_name in metadata
         assert config.file_name is None
 
 
-def test_every_generator_appears_in_each_of_its_categories():
+def test_each_generator_sits_under_its_primary_category():
     metadata = generators.load_metadata()
-    seen: dict[str, set[str]] = {}
-    for _, config in _all_configs():
-        seen.setdefault(config.dataset_name, set()).add(config.dataset_category)
-    for name, entry in metadata.items():
-        assert seen[name] == set(entry["categories"]), name
-
-
-def test_deduping_by_generator_recovers_exactly_54_tasks():
-    names = {config.dataset_name for _, config in _all_configs()}
-    assert len(names) == 54
+    for config in _configs():
+        assert (
+            config.dataset_category
+            == metadata[config.dataset_name]["primary_category"]
+        )
 
 
 def test_declared_variables_match_the_generator_output_width():
-    for _, config in _all_configs():
-        width = generators.generate(config.dataset_name, T=8, seed=0)
-        columns = 1 if width.ndim == 1 else width.shape[1]
+    for config in _configs():
+        series = generators.generate(config.dataset_name, T=8, seed=0)
+        columns = 1 if series.ndim == 1 else series.shape[1]
         declared = len(config.target_variable_names) + len(
             config.covariate_variable_names
         )
         assert declared == columns, config.dataset_name
 
 
+def test_inferred_task_mode_agrees_with_the_registry_variate():
+    metadata = generators.load_metadata()
+    for config in _configs():
+        assert config.task_mode == metadata[config.dataset_name]["variate"]
+
+
 def test_count_and_binary_targets_are_not_standardised():
-    for _, config in _all_configs():
+    for config in _configs():
         if config.target_type != "continuous_real":
             assert config.normalization_method == "none", config.dataset_name
 
@@ -65,49 +89,29 @@ def test_count_and_binary_targets_are_not_standardised():
 def test_window_exceptions_from_the_design_doc_are_applied():
     windows = {
         config.dataset_name: (config.context_window, config.forecast_horizon)
-        for _, config in _all_configs()
+        for config in _configs()
     }
     assert windows["multi_seasonal"][0] >= 512
     assert windows["logistic_map"][1] <= 20
     assert windows["mv_leadlag"][1] == 16
 
 
-def test_task_path_pattern_recognises_the_synthetic_catalog():
-    from tempus_bench.utils.task_yaml_loader import is_synthetic_task_path
-
-    assert is_synthetic_task_path("Synthetic Tasks")
-    assert is_synthetic_task_path("Synthetic Tasks/Trend")
-    assert not is_synthetic_task_path("covariate/covariate_transport_monthly")
-
-
-def test_a_single_category_pattern_loads_only_that_category():
-    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
-
-    configs = load_synthetic_task_configs("Synthetic Tasks/Trend")
-    assert configs
-    assert {c.dataset_category for c in configs} == {"trend"}
-
-
-def test_whole_bed_dedupes_to_one_document_per_generator():
-    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
-
-    configs = load_synthetic_task_configs("Synthetic Tasks")
-    names = [c.dataset_name for c in configs]
-    assert len(names) == len(set(names)) == 54
-
-
-def test_whole_bed_keeps_each_generator_under_its_primary_category():
-    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
-
+def test_every_category_tag_is_recoverable_from_the_registry():
+    """Tasks appear once, so per-category reporting reads tags from metadata."""
     metadata = generators.load_metadata()
-    for config in load_synthetic_task_configs("Synthetic Tasks"):
-        assert config.dataset_category == metadata[config.dataset_name]["primary_category"]
+    tagged_trend = {
+        name for name, entry in metadata.items() if "trend" in entry["categories"]
+    }
+    assert len(tagged_trend) == 16
+    primary_trend = {
+        config.dataset_name
+        for config in _configs()
+        if config.dataset_category == "trend"
+    }
+    assert primary_trend < tagged_trend
 
 
-def test_unknown_category_is_reported():
-    import pytest
-
-    from tempus_bench.utils.task_yaml_loader import load_synthetic_task_configs
-
-    with pytest.raises(FileNotFoundError, match="Synthetic category file not found"):
-        load_synthetic_task_configs("Synthetic Tasks/NoSuchCategory")
+@pytest.mark.parametrize("field", ["series_length", "target_type"])
+def test_generator_only_fields_are_populated(field):
+    for config in _configs():
+        assert getattr(config, field) is not None, config.dataset_name

--- a/tests/unit/test_synthetic_task_yaml.py
+++ b/tests/unit/test_synthetic_task_yaml.py
@@ -1,0 +1,70 @@
+"""Building TaskConfig objects from generator catalog documents."""
+
+import pytest
+
+from tempus_bench.utils.task_yaml_loader import build_task_config_from_raw
+
+
+def _raw(**overrides):
+    raw = {
+        "task_name": "Irregular Period Seasonal",
+        "task_description": "Drifting period sinusoid.",
+        "context_window": 512,
+        "forecast_horizon": 64,
+        "handle_missing": "interpolate",
+        "normalization_method": "standard",
+        "task_catalog": "synthetic",
+        "dataset_category": "seasonality",
+        "dataset_name": "irregular_period_seasonal",
+        "target_type": "continuous_real",
+        "series_length": 2048,
+        "target_variable_names": ["y"],
+        "covariate_variable_names": [],
+    }
+    raw.update(overrides)
+    return raw
+
+
+def test_generator_task_carries_no_file_name():
+    config = build_task_config_from_raw(_raw())
+    assert config.is_synthetic()
+    assert config.file_name is None
+    assert config.dataset_name == "irregular_period_seasonal"
+    assert config.series_length == 2048
+    assert config.target_type == "continuous_real"
+    assert config.generator_params == {}
+
+
+def test_application_task_still_derives_its_csv_name():
+    config = build_task_config_from_raw(
+        _raw(task_catalog="application", dataset_name="Daily_Corn_Futures")
+    )
+    assert not config.is_synthetic()
+    assert config.file_name == "Daily_Corn_Futures.csv"
+
+
+def test_mode_is_inferred_from_the_variable_lists():
+    assert build_task_config_from_raw(_raw()).task_mode == "univariate"
+    assert (
+        build_task_config_from_raw(
+            _raw(target_variable_names=["y1", "y2"])
+        ).task_mode
+        == "multivariate"
+    )
+    assert (
+        build_task_config_from_raw(
+            _raw(covariate_variable_names=["x"])
+        ).task_mode
+        == "covariate"
+    )
+
+
+def test_generator_params_are_passed_through():
+    config = build_task_config_from_raw(_raw(generator_params={"sigma": 2.0}))
+    assert config.generator_params == {"sigma": 2.0}
+
+
+def test_generator_task_has_no_dataset_adapter():
+    config = build_task_config_from_raw(_raw())
+    with pytest.raises(AttributeError, match="no dataset file"):
+        _ = config.dataset

--- a/tests/unit/test_task_dataset_paths.py
+++ b/tests/unit/test_task_dataset_paths.py
@@ -1,0 +1,23 @@
+"""Pickle filenames for prepared task datasets."""
+
+from tempus_bench.utils.paths import task_dataset_filename
+
+
+def test_application_tasks_keep_the_unsuffixed_name():
+    assert task_dataset_filename("Daily Corn Futures", None) == "Daily Corn Futures.pkl"
+
+
+def test_generator_tasks_are_suffixed_with_the_base_seed():
+    assert task_dataset_filename("Random Walk", 0) == "Random Walk__seed0.pkl"
+    assert task_dataset_filename("Random Walk", 12) == "Random Walk__seed12.pkl"
+
+
+def test_distinct_seeds_never_share_a_filename():
+    names = {task_dataset_filename("Random Walk", seed) for seed in range(50)}
+    assert len(names) == 50
+
+
+def test_seeded_name_never_collides_with_the_unseeded_one():
+    assert task_dataset_filename("Random Walk", 0) != task_dataset_filename(
+        "Random Walk", None
+    )


### PR DESCRIPTION
Adds the 54 data generators to the evaluation pipeline as real tasks, generated on the fly instead of downloaded.

## The idea

An application task YAML **points at a file**. A generator task YAML is a **recipe**: which generator, how long, what seed. Both end up as the same `Dataset` object, so nothing downstream changes.

## What changed

**1. Generators are a package.** `tempus_bench/generators/`, one file per generator plus `metadata.json` holding each one's id, categories, description and default windows. Adding a task = adding one file and one entry.

**2. Seeds live in `benchmark.yaml`.** Each generator's seed is derived from the base seed and its id, so no two generators ever draw the same vector.

```yaml
evaluation:
  seeds: [0, 1, 2]      # one int, or a list
```

**3. Data is generated at load time.** One branch in `DataLoader`: instead of reading a CSV it calls the generator and stamps a regular hourly index.

**4. One dataset per seed.** Every model in a run sees identical data for a given seed; a new seed gives a fresh draw.

**5. Hyperparameters are selected on the seed average.** Each configuration runs on every seed and the winner has the lowest mean loss. Models overfit individual seeds, so selecting on one inflates the result.

**6. The catalog is generated.** `Tasks/Synthetic Tasks/`, one YAML per category, built from `metadata.json` so it can't drift.

## Testing

107 new tests. Zero regressions: I ran the suite on `origin/dev` in a separate worktree and diffed the failure sets, they're identical.

Two things worth calling out:
- Before deleting the old `synthetic_generators.py` I ran all 54 generators through both the old and new code across three seeds and confirmed identical output. The split changed no math.
- A test mirrors the dataset-preparation loop and builds all 54 generators as real `Dataset` objects across multiple seeds.

Application tasks are untouched: they keep their filenames, and single-seed runs keep the existing selection path exactly.

## Three things to look at

**1. Seed stride.** Deni asked for `base_seed + generator_id`. Plain addition collides: base 5 + id 3 equals base 6 + id 2, so changing the base seed makes some generators reproduce draws other generators already used, which is what the id was meant to prevent. I multiply the base first (`base * 10_000 + id`). Same design, one line different. Say the word and I'll switch it back.

**2. Each generator appears once, not once per category.** The catalog loader rejects duplicate `task_name`, so a generator tagged with five categories can't appear in five files. Each one sits under its primary category and the full tag list stays in `metadata.json`, which is where per-category reporting should read it from. Side effect: `trend/*` selects the 8 generators whose *primary* category is trend, not all 16 tagged with it.

**3. Pre-existing bug on `dev`, not from this PR.** `load_all_task_documents()` raises on a duplicate `task_name`: `Skoltech Anomaly Benchmark (SKAB)` appears twice in `Tasks/Application Tasks/manufacturing_and_industrial_production.yaml`, once for `Seconds_SKAB_Pressure` and once for `Seconds_SKAB_Pressure_Covariate`. Task discovery fails on `dev` today, so any run does. @Omkar it's your file, so I left it alone; a rename fixes it.

## Not in scope

Metrics by target type. There are 9 metrics and all assume continuous targets, so `binary_latent_ar` and `ordinal_categorical` have no valid metric and `mape` divides by the actual, which breaks on the zero-heavy intermittency tasks. Needs a decision before those tasks report meaningful numbers.
